### PR TITLE
AMC: Stage 5a deployment execution functional delivery retrofit

### DIFF
--- a/.agent-admin/wave-records/amc-wave-record-1190-current.md
+++ b/.agent-admin/wave-records/amc-wave-record-1190-current.md
@@ -2,7 +2,7 @@
 
 PR: #1190
 Issue: #1189
-Reviewed SHA: 45cd09ed147c3ed7daab8065dcaad22cc969c185
+Reviewed SHA: f1bf1bfbfaf046bd15e8da339c14a9e1d2c64c35
 Verdict: PASS
 PHASE_B_BLOCKING_TOKEN: IAA-session-1190-20260629-PASS
 ecap_waiver_ref: CS2-proxy-admin-loop-control-PR1190-20260629
@@ -12,16 +12,17 @@ Reviewed files:
 - modules/amc/05a-deployment-execution-strategy/deployment-execution-validation-matrix.md
 - modules/amc/05a-deployment-execution-strategy/stage5a-functional-delivery-change-propagation-audit.md
 - modules/amc/BUILD_PROGRESS_TRACKER.md
+- modules/amc/AMC_PRE_BUILD_ARTIFACT_INDEX.md
 
 This is a Stage 5a retrofit review record for CS2 review.
 
 ## ECAP Loop Control
 
-The protected-path condition is caused by tracker and deployment-execution documentation updates in PR #1190.
+The protected-path condition is caused by tracker, artifact-index, and deployment-execution documentation updates in PR #1190.
 
 No ECAP reconciliation bundle is placed under `.agent-admin/prehandover/`. This PR uses the explicit ECAP waiver reference above and does not claim handover authorization.
 
 delta_assurance_verdict: PASS
 base_head: 713d30c32bd2c2b3b9c636dd51b6c14bba30c360
-final_head: 45cd09ed147c3ed7daab8065dcaad22cc969c185
+final_head: f1bf1bfbfaf046bd15e8da339c14a9e1d2c64c35
 delta_classification: token-recording-only

--- a/.agent-admin/wave-records/amc-wave-record-1190-current.md
+++ b/.agent-admin/wave-records/amc-wave-record-1190-current.md
@@ -1,0 +1,27 @@
+# AMC Wave Record Current — PR #1190
+
+PR: #1190
+Issue: #1189
+Reviewed SHA: 45cd09ed147c3ed7daab8065dcaad22cc969c185
+Verdict: PASS
+PHASE_B_BLOCKING_TOKEN: IAA-session-1190-20260629-PASS
+ecap_waiver_ref: CS2-proxy-admin-loop-control-PR1190-20260629
+
+Reviewed files:
+- modules/amc/05a-deployment-execution-strategy/functional-delivery-deployment-execution-addendum.md
+- modules/amc/05a-deployment-execution-strategy/deployment-execution-validation-matrix.md
+- modules/amc/05a-deployment-execution-strategy/stage5a-functional-delivery-change-propagation-audit.md
+- modules/amc/BUILD_PROGRESS_TRACKER.md
+
+This is a Stage 5a retrofit review record for CS2 review.
+
+## ECAP Loop Control
+
+The protected-path condition is caused by tracker and deployment-execution documentation updates in PR #1190.
+
+No ECAP reconciliation bundle is placed under `.agent-admin/prehandover/`. This PR uses the explicit ECAP waiver reference above and does not claim handover authorization.
+
+delta_assurance_verdict: PASS
+base_head: 713d30c32bd2c2b3b9c636dd51b6c14bba30c360
+final_head: 45cd09ed147c3ed7daab8065dcaad22cc969c185
+delta_classification: token-recording-only

--- a/modules/amc/05a-deployment-execution-strategy/deployment-execution-validation-matrix.md
+++ b/modules/amc/05a-deployment-execution-strategy/deployment-execution-validation-matrix.md
@@ -1,0 +1,86 @@
+# AMC Stage 5a Deployment Execution Validation Matrix
+
+**Stage**: 5a — Deployment execution validation matrix  
+**Module**: App Management Centre (AMC)  
+**Version**: 1.0  
+**Status**: Produced for CS2 review  
+**Wave**: amc-stage5a-deployment-execution-retrofit-20260626  
+**Issue**: app_management_centre#1189  
+**Authority basis**: TR-1910, Stage 5 architecture map, Stage 5 review notes, existing Stage 5a DES artifacts  
+**Non-scope**: This matrix does not start Stage 6, Stage 7, Stage 8, builder checklist, IAA pre-brief, builder appointment, or implementation work.
+
+---
+
+## 1. Purpose
+
+This matrix converts the Stage 5a deployment execution strategy into validation and evidence obligations. It exists so Stage 6 QA-to-Red and Stage 7 PBFAG can derive deployment-execution tests without guessing.
+
+---
+
+## 2. Validation Matrix
+
+| Validation domain | Required execution rule | Evidence required later | Failure class if missing | Downstream owner |
+|---|---|---|---|---|
+| Workflow ownership | `ci.yml`, `deploy-frontend.yml`, and `db-migrate.yml` are the only named automated workflow families unless CS2 amends Stage 5a | workflow file names and trigger review | undocumented workflow ownership | Stage 6 / Stage 7 |
+| Frontend/API deployment | frontend and Next.js API routes deploy as one Vercel unit | Vercel deployment log and deployed URL | frontend/backend split ambiguity | Stage 6 / Stage 8 |
+| Production approval | production deploy and production migration use protected `production` environment | GitHub environment gate evidence | ungated production action | Stage 6 / Stage 7 |
+| Migration mechanism | Supabase CLI `supabase db push --project-ref $SUPABASE_PROJECT_REF` only | workflow command inspection and migration log | speculative migration path | Stage 6 / Stage 7 |
+| Migration rollback | rollback/revert procedure must be defined before implementation waves close | rollback note, backup/restore reference, migration revert plan | no rollback evidence | Stage 5a / Stage 8 |
+| Environment template | root `.env.example` defines required variables and placeholders only | `.env.example` present and no committed secrets | missing configuration contract | Stage 6 |
+| Secret isolation | production secrets only in `production` environment; no production DB credentials in PR/staging | workflow/env review | production secret leakage | Stage 6 / Stage 7 |
+| CI boundary | PR CI may run lint/type/test/schema verification but no production mutation | workflow trigger and secret scope review | CI mutates production | Stage 6 / Stage 7 |
+| Preview boundary | preview deploy uses staging/preview resources only | preview env config evidence | preview uses production data | Stage 6 / Stage 7 |
+| Live validation | post-deployment manual validation executed by CS2/designated operator | validation checklist/log/screenshots where applicable | no live evidence | Stage 7 / Stage 8 |
+| Runtime health | app health, API reachability, Supabase connectivity, realtime, and core route availability checked | smoke log or manual validation record | unvalidated runtime | Stage 6 / Stage 7 |
+| Audit validation | consequential action creates audit/provenance event | audit record proof for first E2E path | missing audit proof | Stage 6 / Stage 7 |
+| First E2E path | `/alerts` acknowledgement path is the first deployment evidence candidate | UI/API/state/audit evidence bundle | no end-to-end proof | Stage 6 / Stage 7 |
+| AIMC readiness | AIMC unavailable state or successful action gateway verified | dependency status evidence | hidden AI dependency failure | Stage 6 / Stage 7 |
+| AIMCC readiness | upload/quota status read degrades visibly when unavailable | status/stale evidence | hidden AIMCC failure | Stage 6 / Stage 7 |
+| KUC readiness | upload submission path uses KUC and surfaces rejection/unavailable state | KUC response/evidence | direct AIMCC ingestion or hidden failure | Stage 6 / Stage 7 |
+| Knowledge readiness | knowledge retrieval requires provenance/stale marker | retrieval proof | unproven/stale knowledge presented as truth | Stage 6 / Stage 7 |
+| Foreman readiness | build-status feed and intervention dispatch boundaries validated | status/dispatch proof or N/A evidence | false Foreman readiness | Stage 6 / Stage 7 |
+| Specialist agent readiness | workspace status/termination boundaries validated if enabled | status and approval-gate evidence | ungoverned workspace action | Stage 6 / Stage 7 |
+| Push readiness | mobile/web push credentials and fallback route validation if enabled | push delivery/open evidence or N/A record | critical alert dead end | Stage 6 / Stage 7 |
+| No placeholder deployment | placeholder deployment evidence cannot satisfy completion | placeholder register and CS2 disposition | placeholder counted complete | Stage 7 |
+
+---
+
+## 3. Required Evidence Package for Later Gates
+
+Before any implementation wave can close, Stage 7/8 must require at least:
+
+1. deployed URL or explicit non-deployment status;
+2. API endpoint proof for affected routes;
+3. state persistence/projection proof;
+4. audit/provenance proof;
+5. environment validation proof;
+6. dependency readiness or degraded-mode proof;
+7. rollback/migration evidence where database changes apply;
+8. screenshots/video/logs for user-visible journeys where applicable;
+9. test logs showing GREEN only after implementation exists.
+
+---
+
+## 4. Stage 6 Derivation Hints
+
+Stage 6 should derive RED tests or validation checks for the following:
+
+- missing workflow file;
+- wrong workflow trigger;
+- production job without protected environment;
+- production secrets available to PR jobs;
+- migration command drift;
+- missing rollback plan;
+- missing `.env.example` entry for required runtime variable;
+- runtime health endpoint unavailable;
+- missing audit event after first E2E path;
+- external dependency unavailable but hidden from user;
+- placeholder evidence counted as complete.
+
+---
+
+## 5. Verdict
+
+This matrix makes the deployment-execution evidence path explicit enough for Stage 6 and Stage 7 to derive tests and gates.
+
+It is not an implementation plan and does not authorize build work.

--- a/modules/amc/05a-deployment-execution-strategy/deployment-execution-validation-matrix.md
+++ b/modules/amc/05a-deployment-execution-strategy/deployment-execution-validation-matrix.md
@@ -4,7 +4,7 @@
 **Module**: App Management Centre (AMC)  
 **Version**: 1.0  
 **Status**: Produced for CS2 review  
-**Wave**: amc-stage5a-deployment-execution-retrofit-20260626  
+**Wave**: amc-stage5a-deployment-execution-retrofit-20260629  
 **Issue**: app_management_centre#1189  
 **Authority basis**: TR-1910, Stage 5 architecture map, Stage 5 review notes, existing Stage 5a DES artifacts  
 **Non-scope**: This matrix does not start Stage 6, Stage 7, Stage 8, builder checklist, IAA pre-brief, builder appointment, or implementation work.

--- a/modules/amc/05a-deployment-execution-strategy/functional-delivery-deployment-execution-addendum.md
+++ b/modules/amc/05a-deployment-execution-strategy/functional-delivery-deployment-execution-addendum.md
@@ -4,7 +4,7 @@
 **Module**: App Management Centre (AMC)  
 **Version**: 1.0  
 **Status**: Produced for CS2 review  
-**Wave**: amc-stage5a-deployment-execution-retrofit-20260626  
+**Wave**: amc-stage5a-deployment-execution-retrofit-20260629  
 **Issue**: app_management_centre#1189  
 **Authority basis**: PR #1186, PR #1188, TR-1910, Stage 5 functional-delivery architecture addendum, Stage 5 architecture map, Stage 5 change-propagation audit  
 **Non-scope**: This addendum does not start Stage 6, Stage 7, Stage 8, builder checklist, IAA pre-brief, builder appointment, or implementation work.

--- a/modules/amc/05a-deployment-execution-strategy/functional-delivery-deployment-execution-addendum.md
+++ b/modules/amc/05a-deployment-execution-strategy/functional-delivery-deployment-execution-addendum.md
@@ -1,0 +1,134 @@
+# AMC Stage 5a Addendum — Functional Delivery Deployment Execution
+
+**Stage**: 5a — Deployment Execution Strategy addendum  
+**Module**: App Management Centre (AMC)  
+**Version**: 1.0  
+**Status**: Produced for CS2 review  
+**Wave**: amc-stage5a-deployment-execution-retrofit-20260626  
+**Issue**: app_management_centre#1189  
+**Authority basis**: PR #1186, PR #1188, TR-1910, Stage 5 functional-delivery architecture addendum, Stage 5 architecture map, Stage 5 change-propagation audit  
+**Non-scope**: This addendum does not start Stage 6, Stage 7, Stage 8, builder checklist, IAA pre-brief, builder appointment, or implementation work.
+
+---
+
+## 1. Purpose
+
+This addendum imports the merged Stage 1-5 functional-delivery controls into Stage 5a Deployment Execution Strategy.
+
+The existing Stage 5a `deployment-execution-strategy.md`, `deployment-surface-ownership-table.md`, and `runner-and-environment-constraints.md` remain the primary deployment-execution artifacts. This addendum does not replace them. It adds a functional-delivery execution layer so deployment planning cannot become speculative or incomplete.
+
+---
+
+## 2. Stage 5a Functional Delivery Rule
+
+A deployment execution strategy is not complete unless it defines how a later implemented capability can be proven live across:
+
+1. workflow ownership;
+2. runner and environment constraints;
+3. environment variable availability;
+4. migration execution and rollback;
+5. deployment trigger and protected approval boundary;
+6. runtime health validation;
+7. dependency readiness validation;
+8. audit/provenance validation;
+9. visible user-facing validation;
+10. deployment evidence capture.
+
+Stage 5a must therefore bind the Stage 5 route/action/state/audit architecture map to deploy-time verification and evidence requirements.
+
+---
+
+## 3. TR-1910 Import
+
+TR-1910 requires Stage 5/5a to freeze deployment and runtime execution behavior with enough precision that builders do not invent operational behavior.
+
+Stage 5a satisfies TR-1910 only if the following are explicit:
+
+| TR-1910 requirement | Stage 5a execution interpretation | Status after this addendum |
+|---|---|---|
+| Deployment surface ownership | `deployment-surface-ownership-table.md` assigns each surface to one owner | CLEAN |
+| Workflow ownership | `deploy-frontend.yml`, `db-migrate.yml`, `ci.yml`, and manual validation are named | CLEAN |
+| Environment/protected gate behavior | `runner-and-environment-constraints.md` defines production/staging boundary | CLEAN |
+| Migration mechanism | Supabase CLI `supabase db push --project-ref $SUPABASE_PROJECT_REF` only | CLEAN |
+| Live validation sequence | Added by `deployment-execution-validation-matrix.md` | CLEAN after retrofit |
+| CI/preview/production boundaries | Existing DES and runner constraints define boundaries | CLEAN |
+| Runtime smoke validation | Added by validation matrix | CLEAN after retrofit |
+| No operational speculation | This addendum prohibits builder invention of workflow/env/migration behavior | CLEAN |
+
+---
+
+## 4. Functional Delivery Deployment Evidence Rule
+
+Stage 6/7/8 may not treat a feature as deployment-ready unless later implementation evidence can show:
+
+- a deployed frontend route or user-visible surface;
+- a working API route or external service contract;
+- state persistence or projection boundary;
+- audit/provenance event creation where consequential;
+- authority gate behavior;
+- degraded-mode behavior for unavailable dependencies;
+- environment variables resolved from the correct environment scope;
+- no production secret leakage into PR/staging jobs;
+- migration path executed or explicitly not applicable;
+- runtime health/smoke result captured;
+- screenshot/video/log evidence where applicable.
+
+---
+
+## 5. Approved Deployment Execution Boundary
+
+The following remains frozen for downstream use unless CS2 approves a Stage 5a amendment:
+
+| Surface | Owner | Deployment/validation rule |
+|---|---|---|
+| Frontend + API routes | `deploy-frontend.yml` | Unified Vercel deployment unit; production requires protected `production` environment approval |
+| DB migration | `db-migrate.yml` | Manual dispatch only; Supabase CLI only; production requires protected approval |
+| Schema verification | `ci.yml` | Read-only CI validation; no DB mutation |
+| Live operational validation | CS2 or designated operator | Manual post-deployment validation with evidence capture |
+| External dependency readiness | runtime smoke/manual validation | AIMC, AIMCC, KUC, knowledge/memory, Foreman, specialist agents, push providers, Supabase, and Vercel readiness must be checked or explicitly marked not applicable |
+
+---
+
+## 6. No-Speculation Rule
+
+Builders and later agents must not invent:
+
+- workflow file names;
+- runner types;
+- environment names;
+- migration commands;
+- production approval gates;
+- rollback sequence;
+- health/smoke validation steps;
+- evidence requirements;
+- external dependency readiness assumptions.
+
+Any missing deployment-execution detail is a Stage 5a DRIFT or AMBIGUITY item, not a builder decision.
+
+---
+
+## 7. Downstream Carry-Forward
+
+Stage 6 must create RED tests or validation checks for:
+
+- required workflow presence and names;
+- forbidden production secrets in PR/staging contexts;
+- no production DB access from PR jobs;
+- `supabase db push --project-ref $SUPABASE_PROJECT_REF` as the only migration command;
+- no `supabase link` step before migrations;
+- production approval gate presence;
+- environment-variable validation;
+- runtime health/smoke validation obligations;
+- deployment evidence package completeness.
+
+Stage 7 must fail or condition Stage 8 if Stage 5a deployment execution remains ambiguous.
+
+Stage 8 remains blocked until Stage 5a, Stage 6, and Stage 7 are CS2-dispositioned.
+
+---
+
+## 8. Stage 5a Disposition Statement
+
+Stage 5a may be treated as functionally aligned only if this addendum, the deployment execution validation matrix, and the Stage 5a change-propagation audit are reviewed and accepted or explicitly dispositioned by CS2.
+
+This addendum does not approve Stage 5a by itself and does not authorize implementation.

--- a/modules/amc/05a-deployment-execution-strategy/stage5a-functional-delivery-change-propagation-audit.md
+++ b/modules/amc/05a-deployment-execution-strategy/stage5a-functional-delivery-change-propagation-audit.md
@@ -5,7 +5,7 @@
 **Module**: App Management Centre (AMC)  
 **Version**: 1.0  
 **Status**: Produced for CS2 review  
-**Wave**: amc-stage5a-deployment-execution-retrofit-20260626  
+**Wave**: amc-stage5a-deployment-execution-retrofit-20260629  
 **Issue**: app_management_centre#1189  
 **Authority basis**: PR #1186, PR #1188, TR-1910, existing Stage 5a deployment-execution artifacts  
 **Non-scope**: This audit does not start Stage 6, Stage 7, Stage 8, builder checklist, IAA pre-brief, builder appointment, or implementation work.

--- a/modules/amc/05a-deployment-execution-strategy/stage5a-functional-delivery-change-propagation-audit.md
+++ b/modules/amc/05a-deployment-execution-strategy/stage5a-functional-delivery-change-propagation-audit.md
@@ -1,0 +1,126 @@
+# AMC Stage 5a Functional Delivery Change-Propagation Audit
+
+**Artifact Type**: Change-Propagation Audit  
+**Stage**: 5a — Deployment Execution Strategy  
+**Module**: App Management Centre (AMC)  
+**Version**: 1.0  
+**Status**: Produced for CS2 review  
+**Wave**: amc-stage5a-deployment-execution-retrofit-20260626  
+**Issue**: app_management_centre#1189  
+**Authority basis**: PR #1186, PR #1188, TR-1910, existing Stage 5a deployment-execution artifacts  
+**Non-scope**: This audit does not start Stage 6, Stage 7, Stage 8, builder checklist, IAA pre-brief, builder appointment, or implementation work.
+
+---
+
+## 1. Purpose
+
+This audit checks whether the existing Stage 5a Deployment Execution Strategy properly absorbs the merged Stage 1-5 functional-delivery controls.
+
+Outcome codes:
+
+| Code | Meaning |
+|---|---|
+| CLEAN | No material gap after this retrofit is applied |
+| ADVISORY | Improvement recommended, but not blocking if recorded |
+| DRIFT | Upstream/downstream mismatch that must be corrected or dispositioned |
+| AMBIGUITY | Later agent/builder would need to invent execution behavior |
+
+---
+
+## 2. Inputs Reviewed
+
+| Input | Review relevance |
+|---|---|
+| `deployment-execution-strategy.md` | Existing Stage 5a primary DES artifact |
+| `deployment-surface-ownership-table.md` | Existing deployment surface ownership matrix |
+| `runner-and-environment-constraints.md` | Existing runner/environment constraints |
+| `functional-delivery-technical-requirements-addendum.md` | TR-1910 deployment-execution carry-forward |
+| `functional-delivery-architecture-addendum.md` | Stage 5 architecture functional-delivery controls |
+| `functional-delivery-architecture-map.md` | Stage 5 route/action/state/audit map |
+| `stage5-functional-delivery-change-propagation-audit.md` | Stage 5 downstream obligations |
+| `.env.example` | Environment contract required by architecture canon |
+
+---
+
+## 3. Stage 5a Findings
+
+| Area | Existing Stage 5a posture | Retrofit finding | Code | Required action / disposition |
+|---|---|---|---|---|
+| DES completeness | Existing DES answers mandatory deployment-execution fields | Strong baseline | CLEAN | Preserve |
+| Workflow ownership | Existing ownership table names CI, deploy, migration, and manual validation owners | Aligns with TR-1910 | CLEAN | Preserve |
+| Runner constraints | GitHub-hosted only; no self-hosted runners required | Clear and testable | CLEAN | Preserve |
+| Migration path | Supabase CLI command is frozen | Aligns with no-speculation rule | CLEAN | Preserve |
+| Protected environments | Production gate defined | Aligns with authority-before-live-action | CLEAN | Preserve |
+| Stage 5 import | Existing DES predates PR #1188 architecture map | Needed explicit import | DRIFT before retrofit | Resolved by Stage 5a addendum |
+| Runtime validation | Existing DES has validation concepts but not full evidence matrix | Needed Stage 6/7 derivation support | DRIFT before retrofit | Resolved by validation matrix |
+| External dependencies | Existing DES focuses on Vercel/Supabase; Stage 5 map adds AIMC/AIMCC/KUC/knowledge/Foreman/specialist/push readiness | Needed deployment evidence coverage | DRIFT before retrofit | Resolved by validation matrix |
+| Audit/provenance evidence | Existing DES does not explicitly bind first E2E audit proof | Needed deployment evidence path | DRIFT before retrofit | Resolved with `/alerts` acknowledgement evidence candidate |
+| Stage 6 handoff | Existing DES mentions inheritance; retrofit needs specific RED derivation hints | Needed detail | CLEAN after retrofit | Stage 6 must import |
+| Stage 8 readiness | Stage 5a cannot authorize Stage 8 alone | Tracker must continue block | CLEAN | Maintain block |
+
+---
+
+## 4. Gap Register
+
+| Gap ID | Gap | Severity | Status after this wave | Downstream action |
+|---|---|---|---|---|
+| AMC-S5A-FD-GAP-001 | Stage 5a predates PR #1188 architecture map | High | Addressed by addendum | CS2 review/disposition required |
+| AMC-S5A-FD-GAP-002 | Deployment evidence package not explicit enough for QA/PBFAG | High | Addressed by validation matrix | Stage 6/7 must import |
+| AMC-S5A-FD-GAP-003 | External dependency readiness not mapped to deploy evidence | High | Addressed by validation matrix | Stage 6/7 must import |
+| AMC-S5A-FD-GAP-004 | First end-to-end deployment evidence path not selected | Medium | Addressed by alert acknowledgement path | Stage 6/7 must validate |
+| AMC-S5A-FD-GAP-005 | Rollback evidence still needs later implementation-specific detail | Medium | Recorded as downstream carry-forward | Stage 8 must complete per wave |
+| AMC-S5A-FD-GAP-006 | Stage 6/7 not yet updated with Stage 5a tests/gates | High | Open by design | Start separate Stage 6 wave after CS2 disposition |
+
+---
+
+## 5. Downstream Propagation Requirements
+
+### Stage 6 must import
+
+- workflow presence/name checks;
+- protected production environment checks;
+- production secret isolation tests;
+- migration command drift tests;
+- rollback-plan evidence checks;
+- runtime health/smoke validation checks;
+- first E2E path audit proof checks;
+- external dependency degraded-mode checks;
+- deployment evidence package checks.
+
+### Stage 7 must import
+
+- hard fail if deployment execution path is ambiguous;
+- hard fail if production actions lack protected approval;
+- hard fail if migration path deviates from the frozen command;
+- hard fail if no deployment evidence package exists;
+- hard fail if placeholders are used as deployment proof.
+
+### Stage 8 remains blocked until
+
+- Stage 5a addendum, validation matrix, and this audit are CS2-dispositioned;
+- Stage 6 QA-to-Red is updated/dispositioned against Stage 5a;
+- Stage 7 PBFAG is updated/dispositioned against Stage 5/5a;
+- CS2 explicitly authorizes Stage 8.
+
+---
+
+## 6. Verdict
+
+The existing Stage 5a Deployment Execution Strategy is not rejected. It is structurally strong and already answers the mandatory deployment-execution fields.
+
+However, it was produced before the Stage 1-5 functional-delivery retrofit was completed. Without this wave, Stage 6 and Stage 7 would not have a sufficiently explicit deployment evidence path for fully functional delivery.
+
+**Verdict**: CONDITIONAL PASS FOR STAGE 5A RETROFIT PRODUCTION; NOT BUILD-READY; NOT STAGE-8-READY.
+
+**Required CS2 disposition**:
+
+1. Accept or amend `functional-delivery-deployment-execution-addendum.md`.
+2. Accept or amend `deployment-execution-validation-matrix.md`.
+3. Accept or amend this change-propagation audit.
+4. Decide whether the existing Stage 5a DES pack may be approved with these addenda attached.
+
+---
+
+## 7. Foreman Closure Statement
+
+This audit completes the Stage 5a retrofit package for review. It does not approve Stage 5a, does not start Stage 6, does not start Stage 7, does not start Stage 8, does not appoint builders, and does not authorize implementation.

--- a/modules/amc/AMC_PRE_BUILD_ARTIFACT_INDEX.md
+++ b/modules/amc/AMC_PRE_BUILD_ARTIFACT_INDEX.md
@@ -2,7 +2,7 @@
 
 **Module**: App Management Centre (AMC)  
 **Lifecycle Model**: 12-Stage Pre-Build Sequence + Stage 5a (PRE_BUILD_STAGE_MODEL_CANON.md v1.0.0; AMC-GOV-OVERSIGHT-001)  
-**Last Updated**: 2026-04-28 (Stage 7 PBFAG artifacts produced approval-pending — wave amc-stage7-pbfag-20260428; issue #1152; Stage 6 red test count corrected to 79 tests/20 families; prior: Stage 6 QA-to-Red pack produced approval-pending — wave amc-stage6-qa-to-red-20260427; issue #1141; prior: Stage 5a Deployment Execution Strategy artifacts produced approval-pending — wave amc-stage5a-deployment-execution-strategy-20260427; issue #1137; prior: Stage 5a Deployment Execution Strategy defined; Stage 5 Architecture artifacts updated to canonical — wave amc-stage5-architecture-20260426; Stage 4 treated as approved for Stage 5 progression per issue #1131; Stage 3 marked CS2-approved; Stage 2 confirmed CS2-approved; Stages 1–3 harmonization pass applied)  
+**Last Updated**: 2026-06-29 (Stage 5a functional-delivery deployment execution retrofit artifacts produced for CS2 review — wave amc-stage5a-deployment-execution-retrofit-20260629; issue #1189; PR #1190. Prior: Stage 5 architecture functional-delivery retrofit merged as approval-pending reference input — issue #1187; PR #1188. Prior: Stage 1-4 functional-delivery retrofit merged — issue #1185; PR #1186.)  
 **Authority**: Maturion Foreman / CS2
 
 ---
@@ -19,9 +19,10 @@ This index catalogs all pre-build artifacts for the AMC module, mapped to their 
 |----------|----------|--------|-------|
 | App Description | `modules/amc/00-app-description/app-description.md` | ✅ Approved Canonical | v1.0, CS2-approved 2026-04-22. Sole authoritative Stage 1 source. Approval ref: #1117. |
 | App Description Approval | `modules/amc/00-app-description/app-description-approval.md` | ✅ Complete | Formal Stage 1 approval record. All fields populated. CS2 ref: #1117. |
+| Functional Delivery Definition | `modules/amc/00-app-description/functional-delivery-definition.md` | 🟡 Retrofit Reference Input | Produced/merged in PR #1186. Adds fully functional delivery definition. CS2 disposition required as part of retrofit chain. |
 | AMC Role Authority & Operating Model | `modules/amc/00-app-description/amc-role-authority-and-operating-model.md` | ⬜ Placeholder | Not complete — document remains a placeholder; authority wording updated to reflect Stage 1 approval. Follow-on work required. Does not block Stage 2. |
 | FM App Description (superseded) | `docs/governance/FM_APP_DESCRIPTION.md` | 📦 Superseded | Retained as historical/provenance reference only. No longer the active canonical Stage 1 source. |
-| App Description (root pointer) | `APP_DESCRIPTION.md` | 📌 Reference Only | Follow-on update to point to new canonical location pending |
+| App Description (root pointer) | `APP_DESCRIPTION.md` | 📌 Reference Only | Follow-on update to point to new canonical location pending. |
 
 ---
 
@@ -31,6 +32,7 @@ This index catalogs all pre-build artifacts for the AMC module, mapped to their 
 |----------|----------|--------|-------|
 | UX Workflow & Wiring Spec | `modules/amc/01-ux-workflow-wiring-spec/ux-workflow-wiring-spec.md` | ✅ Approved Canonical | v1.1, CS2-approved 2026-04-22. Harmonization pass applied 2026-04-23: ARC Governance Console journey and Dynamic Upload Quota Management Console journey added. Issue #1121. |
 | Wiring Artifact Index | `modules/amc/01-ux-workflow-wiring-spec/wiring-artifact-index.md` | ✅ Approved Canonical | v1.0, CS2-approved 2026-04-22. Issue #1121. |
+| CTA/API/Data/Audit Contract Matrix | `modules/amc/01-ux-workflow-wiring-spec/cta-api-data-audit-contract-matrix.md` | 🟡 Retrofit Reference Input | Produced/merged in PR #1186. Canonical endpoint/event authority remains with Stage 4 TRS. |
 
 ---
 
@@ -40,6 +42,7 @@ This index catalogs all pre-build artifacts for the AMC module, mapped to their 
 |----------|----------|--------|-------|
 | Functional Requirements Specification | `modules/amc/02-frs/functional-requirements-specification.md` | ✅ Approved Canonical | v1.1, CS2-approved for Stage 4 progression 2026-04-23. Harmonization pass applied 2026-04-23: FR-1800 ARC Governance Console family added; FR-606/FR-607 operational quota management requirements added. Approval ref: #1123. |
 | App Description to FRS Traceability | `modules/amc/02-frs/app-description-to-frs-traceability.md` | ✅ Approved Canonical | v1.0, CS2-approved for Stage 4 progression 2026-04-23. Approval ref: #1123. |
+| Functional Delivery Requirements Addendum | `modules/amc/02-frs/functional-delivery-requirements-addendum.md` | 🟡 Retrofit Reference Input | FR-1900 produced/merged in PR #1186. CS2 disposition required as part of retrofit chain. |
 
 ---
 
@@ -47,8 +50,9 @@ This index catalogs all pre-build artifacts for the AMC module, mapped to their 
 
 | Artifact | Location | Status | Notes |
 |----------|----------|--------|-------|
-| Technical Requirements Specification | `modules/amc/03-trs/technical-requirements-specification.md` | 🟠 Treated as Approved | v1.1, hardened approval-ready 2026-04-23. ARC domain (TR-1800), quota console (TR-605–TR-609), alert contract family (TR-207–TR-209), audit/auth/state contract family declarations added. Upstream sources updated to v1.1 per harmonization pass. Stage 4 treated as approved for Stage 5 progression per CS2 #1131. Formal CS2 approval pending. Issue #1125 (hardened in #1127). |
-| FRS to TRS Traceability | `modules/amc/03-trs/frs-to-trs-traceability.md` | 🟠 Treated as Approved | v1.1, hardened 2026-04-23. 18 domain families traced (17 FRS + ARC), 30 deferred items disclosed, quota console and ARC coverage added. Stage 4 treated as approved for Stage 5 progression per CS2 #1131. Issue #1125 (hardened in #1127). |
+| Technical Requirements Specification | `modules/amc/03-trs/technical-requirements-specification.md` | 🟠 Treated as Approved | v1.1, hardened approval-ready 2026-04-23. Stage 4 treated as approved for Stage 5 progression per CS2 #1131. Formal CS2 approval pending. |
+| FRS to TRS Traceability | `modules/amc/03-trs/frs-to-trs-traceability.md` | 🟠 Treated as Approved | v1.1, hardened 2026-04-23. Stage 4 treated as approved for Stage 5 progression per CS2 #1131. |
+| Functional Delivery Technical Requirements Addendum | `modules/amc/03-trs/functional-delivery-technical-requirements-addendum.md` | 🟡 Retrofit Reference Input | TR-1900, including TR-1910, produced/merged in PR #1186. CS2 disposition required as part of retrofit chain. |
 
 ---
 
@@ -58,9 +62,14 @@ This index catalogs all pre-build artifacts for the AMC module, mapped to their 
 |----------|----------|--------|-------|
 | Architecture Specification | `modules/amc/04-architecture/architecture-specification.md` | 🟡 Approval Pending | v1.0, produced 2026-04-26. Canonical Stage 5 artifact. CS2 approval required. Wave: amc-stage5-architecture-20260426. CS2 auth: #1131. |
 | TRS-to-Architecture Traceability | `modules/amc/04-architecture/trs-to-architecture-traceability.md` | 🟡 Approval Pending | v1.0, produced 2026-04-26. 18/18 TRS families realized. CS2 auth: #1131. |
-| Architecture (superseded placeholder) | `modules/amc/04-architecture/architecture.md` | 📦 Superseded | Updated 2026-04-26 with SUPERSEDED notice. `architecture-specification.md` is the canonical Stage 5 artifact. |
-| Architecture Decision Records | `modules/amc/04-architecture/architecture-decision-records.md` | ⬜ Placeholder | Not started |
-| Architecture Completeness Checklist | `modules/amc/04-architecture/architecture-completeness-checklist.md` | ⬜ Placeholder | Not started |
+| Functional Delivery Architecture Addendum | `modules/amc/04-architecture/functional-delivery-architecture-addendum.md` | 🟡 Retrofit Reference Input | Produced/merged in PR #1188. Imports FR-1900/TR-1900 into Stage 5 architecture. CS2 disposition required. |
+| Functional Delivery Architecture Map | `modules/amc/04-architecture/functional-delivery-architecture-map.md` | 🟡 Retrofit Reference Input | Produced/merged in PR #1188. Route/action/state/audit/degraded-mode map for Stage 6 derivation. CS2 disposition required. |
+| Stage 5 Functional Delivery Change-Propagation Audit | `modules/amc/04-architecture/stage5-functional-delivery-change-propagation-audit.md` | 🟡 Retrofit Reference Input | Produced/merged in PR #1188. Conditional pass for retrofit production; not build-ready and not Stage-8-ready. |
+| Stage 5 Review Notes | `modules/amc/04-architecture/stage5-review-notes.md` | 🟡 Retrofit Reference Input | Produced/merged in PR #1188. Records architecture checklist review notes. |
+| Stage 5 Coverage Note | `modules/amc/04-architecture/extra-review-note.md` | 🟡 Retrofit Reference Input | Produced/merged in PR #1188. Records coverage rows required by the architecture template. |
+| Architecture (superseded placeholder) | `modules/amc/04-architecture/architecture.md` | 📦 Superseded | `architecture-specification.md` is the canonical Stage 5 artifact. |
+| Architecture Decision Records | `modules/amc/04-architecture/architecture-decision-records.md` | ⬜ Placeholder | Not started. |
+| Architecture Completeness Checklist | `modules/amc/04-architecture/architecture-completeness-checklist.md` | ⬜ Placeholder | Not started / remains a placeholder unless separately populated. |
 
 ---
 
@@ -68,17 +77,21 @@ This index catalogs all pre-build artifacts for the AMC module, mapped to their 
 
 > **Stage 5a Definition Authority**: `modules/amc/governance-oversight/DEPLOYMENT_STRATEGY_OVERSIGHT.md` (AMC-GOV-OVERSIGHT-001 v1.0)  
 > **CS2 Authorization**: app_management_centre#1133  
-> **Governing Delivery Issue**: app_management_centre#1137  
-> **Status**: 🟡 Artifacts produced — CS2 approval pending  
-> **Entry Condition**: Stage 5 complete and CS2-approved (Stage 5 approval still pending)  
-> **Blocks**: Stage 6 (QA-to-Red) and all subsequent stages
+> **Current Retrofit Issue**: app_management_centre#1189  
+> **Current Retrofit PR**: app_management_centre#1190  
+> **Status**: 🟡 Retrofit produced — CS2 review/disposition pending  
+> **Entry Condition**: Stage 5 retrofit package merged as reference input; formal Stage 5 approval/disposition still required before Stage 8.  
+> **Blocks**: Stage 6 retrofit/disposition, Stage 7 final disposition, Stage 8, and all subsequent build-readiness activities.
 
 | Artifact | Location | Status | Notes |
 |----------|----------|--------|-------|
-| Deployment Execution Strategy | `modules/amc/05a-deployment-execution-strategy/deployment-execution-strategy.md` | 🟡 Approval Pending | v1.0, produced 2026-04-27. All 8 DES mandatory fields answered (DES-001 through DES-008). No TBD fields. Single approved migration mechanism: Supabase CLI. CS2 sign-off section included. CS2 approval required. Wave: amc-stage5a-deployment-execution-strategy-20260427. |
-| Deployment Surface Ownership Table | `modules/amc/05a-deployment-execution-strategy/deployment-surface-ownership-table.md` | 🟡 Approval Pending | v1.0, produced 2026-04-27. 5-surface ownership matrix (SURF-001–005). All surfaces owned. No ownership gaps. CS2 approval required. |
-| Runner and Environment Constraints | `modules/amc/05a-deployment-execution-strategy/runner-and-environment-constraints.md` | 🟡 Approval Pending | v1.0, produced 2026-04-27. GitHub-hosted runners only (ubuntu-latest). Protected environment configuration. CI-safe/preview-safe/live-only safety table. Environment prerequisites and network assumptions. CS2 approval required. |
-| Governance Oversight Record | `modules/amc/governance-oversight/DEPLOYMENT_STRATEGY_OVERSIGHT.md` | ✅ COMPLETE — v1.0 | Formal oversight record: gap declaration, Stage 5a definition, required content specification (8 mandatory fields), implementation-plan requirements, anti-drift governance language, corrective action roadmap. CS2 auth: #1133. |
+| Deployment Execution Strategy | `modules/amc/05a-deployment-execution-strategy/deployment-execution-strategy.md` | 🟡 Approval Pending | v1.0, produced 2026-04-27. All 8 DES mandatory fields answered. CS2 approval required. |
+| Deployment Surface Ownership Table | `modules/amc/05a-deployment-execution-strategy/deployment-surface-ownership-table.md` | 🟡 Approval Pending | v1.0, produced 2026-04-27. 5-surface ownership matrix. CS2 approval required. |
+| Runner and Environment Constraints | `modules/amc/05a-deployment-execution-strategy/runner-and-environment-constraints.md` | 🟡 Approval Pending | v1.0, produced 2026-04-27. GitHub-hosted runners only. CS2 approval required. |
+| Functional Delivery Deployment Execution Addendum | `modules/amc/05a-deployment-execution-strategy/functional-delivery-deployment-execution-addendum.md` | 🟡 Retrofit Produced for CS2 Review | Produced in PR #1190. Imports TR-1910, Stage 5 architecture map, deployment evidence, runtime health/smoke validation, dependency readiness, and no-operational-speculation controls. |
+| Deployment Execution Validation Matrix | `modules/amc/05a-deployment-execution-strategy/deployment-execution-validation-matrix.md` | 🟡 Retrofit Produced for CS2 Review | Produced in PR #1190. Adds workflow, environment, migration, protected approval, health, rollback, dependency, audit, and evidence validation obligations for Stage 6/7 derivation. |
+| Stage 5a Functional Delivery Change-Propagation Audit | `modules/amc/05a-deployment-execution-strategy/stage5a-functional-delivery-change-propagation-audit.md` | 🟡 Retrofit Produced for CS2 Review | Produced in PR #1190. Conditional pass for Stage 5a retrofit production; not build-ready and not Stage-8-ready. |
+| Governance Oversight Record | `modules/amc/governance-oversight/DEPLOYMENT_STRATEGY_OVERSIGHT.md` | ✅ COMPLETE — v1.0 | Formal oversight record: gap declaration, Stage 5a definition, required content specification, implementation-plan requirements, anti-drift governance language, corrective action roadmap. CS2 auth: #1133. |
 
 ---
 
@@ -86,33 +99,32 @@ This index catalogs all pre-build artifacts for the AMC module, mapped to their 
 
 | Artifact | Location | Status | Notes |
 |----------|----------|--------|-------|
-| QA-to-Red Specification | `modules/amc/05-qa-to-red/qa-to-red-specification.md` | 🟡 Approval Pending | v1.0, produced 2026-04-27. Core Stage 6 spec: pass/fail philosophy, 4-level severity model, blocker/non-blocker rules, retest protocol, evidence requirements. 12 architecture-derived coverage families (§7) + 7 DES-derived coverage families (§8) + literal-operability checks (§9) + anti-drift posture (§10) + CS2 sign-off section. CS2 approval required. Governing issue: #1141. |
-| Architecture and DES to QA Traceability | `modules/amc/05-qa-to-red/architecture-and-des-to-qa-traceability.md` | 🟡 Approval Pending | v1.0, produced 2026-04-27. Traceability matrix: all 12 Stage 5 Architecture domains + all 8 DES fields (DES-001 through DES-008) traced to Stage 6 red test IDs. Zero silently omitted. Explicit omission register for Stage 12 deferrals. Coverage completeness verdict: 12/12 Architecture domains, 8/8 DES fields. |
-| Red Test Catalog | `modules/amc/05-qa-to-red/red-test-catalog.md` | 🟡 Approval Pending | v1.0, produced 2026-04-27. **79 test cases across 20 families** (corrected from prior erroneous count of 69/17). Each entry: test ID, source artifact, scenario, exact fail condition, exact pass condition, severity (CRITICAL/HIGH/MEDIUM/LOW), blocker classification, evidence type. 21 CRITICAL, 54 HIGH, 4 MEDIUM tests; 75 blockers. |
+| QA-to-Red Specification | `modules/amc/05-qa-to-red/qa-to-red-specification.md` | 🟡 Approval Pending | v1.0, produced 2026-04-27. Must later import Stage 5/5a functional-delivery and deployment-execution retrofit obligations. |
+| Architecture and DES to QA Traceability | `modules/amc/05-qa-to-red/architecture-and-des-to-qa-traceability.md` | 🟡 Approval Pending | v1.0, produced 2026-04-27. Must be reconciled with Stage 5/5a retrofit maps before Stage 8. |
+| Red Test Catalog | `modules/amc/05-qa-to-red/red-test-catalog.md` | 🟡 Approval Pending | v1.0, produced 2026-04-27. 79 test cases across 20 families. Must add/import retrofit failure classes before Stage 8. |
 | QA-to-Red Suite (superseded placeholder) | `modules/amc/05-qa-to-red/qa-to-red-suite.md` | ⛔ Superseded | Placeholder superseded by qa-to-red-specification.md v1.0. Retained for path continuity. |
 | QA Catalog Alignment (superseded placeholder) | `modules/amc/05-qa-to-red/qa-catalog-alignment.md` | ⛔ Superseded | Placeholder superseded by architecture-and-des-to-qa-traceability.md v1.0. Retained for path continuity. |
 
-> **Gate condition**: Stage 7 (PBFAG) is BLOCKED until Stage 5 (Architecture), Stage 5a (DES), and Stage 6 (QA-to-Red) all receive CS2 approval. Governing issue: app_management_centre#1141.
+> **Gate condition**: Stage 7 / Stage 8 remain blocked until Stage 5, Stage 5a, Stage 6, and Stage 7 are CS2-dispositioned. Stage 6 must import Stage 5/5a retrofit obligations before Stage 8 planning.
 
 ---
 
 ## Stage 7 — PBFAG
 
-> **Stage 7 Governing Delivery Issue**: app_management_centre#1152
-> **CS2 Authorization**: app_management_centre#1152 (CS2 authorized parallel production while Stages 5/5a/6 are approval-pending)
-> **Wave**: amc-stage7-pbfag-20260428
-> **Status**: 🟡 Artifacts produced — CS2 approval pending
-> **Entry Condition**: EXCEPTION — Stages 5, 5a, and 6 still approval-pending; CS2 authorized Stage 7 parallel production per #1152
+> **Stage 7 Governing Delivery Issue**: app_management_centre#1152  
+> **CS2 Authorization**: app_management_centre#1152  
+> **Wave**: amc-stage7-pbfag-20260428  
+> **Status**: 🟡 Artifacts produced — CS2 approval pending  
 > **Blocks**: Stage 8 (Implementation Plan) and all subsequent stages
 
 | Artifact | Location | Status | Notes |
 |----------|----------|--------|-------|
-| Pre-Build Final Assurance Gate | `modules/amc/06-pbfag/pre-build-final-assurance-gate.md` | 🟡 Approval Pending | v1.0, produced 2026-04-28. Master PBFAG gate artifact. 10-category evaluation of Stages 1–6. CONDITIONAL PASS verdict. Stage 8 gate conditions explicit. CS2 sign-off section included. CS2 approval required. |
-| PBFAG Evidence Matrix | `modules/amc/06-pbfag/pbfag-evidence-matrix.md` | 🟡 Approval Pending | v1.0, produced 2026-04-28. 81 checks across 10 categories. PASS: 53, PASS-WITH-NOTE: 1, CONDITIONAL: 27, FAIL: 0. All checks verified against canonical upstream artifacts. CS2 approval required. |
-| PBFAG Findings and Verdict | `modules/amc/06-pbfag/pbfag-findings-and-verdict.md` | 🟡 Approval Pending | v1.0, produced 2026-04-28. Verdict: CONDITIONAL PASS. 0 blocking findings. Stage 8 gate condition: 4 CS2 approvals required (Stages 5, 5a, 6, 7). CS2 approval required. |
+| Pre-Build Final Assurance Gate | `modules/amc/06-pbfag/pre-build-final-assurance-gate.md` | 🟡 Approval Pending | v1.0, produced 2026-04-28. Must be reconciled with Stage 5/5a retrofit obligations before Stage 8. |
+| PBFAG Evidence Matrix | `modules/amc/06-pbfag/pbfag-evidence-matrix.md` | 🟡 Approval Pending | v1.0, produced 2026-04-28. Must include tracker/index agreement for new retrofit artifacts before final Stage 8 disposition. |
+| PBFAG Findings and Verdict | `modules/amc/06-pbfag/pbfag-findings-and-verdict.md` | 🟡 Approval Pending | v1.0, produced 2026-04-28. Stage 8 gate remains conditional. |
 | PBFAG Checklist | `modules/amc/06-pbfag/pbfag-checklist.md` | 🟡 Active Wave | Updated to active wave posture; references canonical PBFAG artifacts. |
 
-> **Gate condition**: Stage 8 (Implementation Plan) is BLOCKED until Stage 5 (Architecture), Stage 5a (DES), Stage 6 (QA-to-Red), AND Stage 7 (PBFAG) all receive CS2 approval. Governing issue: app_management_centre#1152.
+> **Gate condition**: Stage 8 is BLOCKED until Stage 5, Stage 5a, Stage 6, and Stage 7 all receive CS2 disposition/approval sufficient to proceed.
 
 ---
 
@@ -120,8 +132,8 @@ This index catalogs all pre-build artifacts for the AMC module, mapped to their 
 
 | Artifact | Location | Status | Notes |
 |----------|----------|--------|-------|
-| Implementation Plan | `modules/amc/07-implementation-plan/implementation-plan.md` | ⬜ Placeholder | Not started |
-| Wave Breakdown | `modules/amc/07-implementation-plan/wave-breakdown.md` | ⬜ Placeholder | Not started |
+| Implementation Plan | `modules/amc/07-implementation-plan/implementation-plan.md` | ⬜ Placeholder | Not started. |
+| Wave Breakdown | `modules/amc/07-implementation-plan/wave-breakdown.md` | ⬜ Placeholder | Not started. |
 
 ---
 
@@ -129,8 +141,8 @@ This index catalogs all pre-build artifacts for the AMC module, mapped to their 
 
 | Artifact | Location | Status | Notes |
 |----------|----------|--------|-------|
-| Builder Checklist | `modules/amc/08-builder-checklist/builder-checklist.md` | ⬜ Placeholder | Not started |
-| Builder Readiness Attestations | `modules/amc/08-builder-checklist/builder-readiness-attestations.md` | ⬜ Placeholder | Not started |
+| Builder Checklist | `modules/amc/08-builder-checklist/builder-checklist.md` | ⬜ Placeholder | Not started. |
+| Builder Readiness Attestations | `modules/amc/08-builder-checklist/builder-readiness-attestations.md` | ⬜ Placeholder | Not started. |
 
 ---
 
@@ -138,8 +150,8 @@ This index catalogs all pre-build artifacts for the AMC module, mapped to their 
 
 | Artifact | Location | Status | Notes |
 |----------|----------|--------|-------|
-| IAA Pre-Brief | `modules/amc/09-iaa-pre-brief/iaa-pre-brief.md` | ⬜ Placeholder | Not started |
-| IAA Pre-Brief Response | `modules/amc/09-iaa-pre-brief/iaa-pre-brief-response.md` | ⬜ Placeholder | Not started |
+| IAA Pre-Brief | `modules/amc/09-iaa-pre-brief/iaa-pre-brief.md` | ⬜ Placeholder | Not started. |
+| IAA Pre-Brief Response | `modules/amc/09-iaa-pre-brief/iaa-pre-brief-response.md` | ⬜ Placeholder | Not started. |
 
 ---
 
@@ -147,8 +159,8 @@ This index catalogs all pre-build artifacts for the AMC module, mapped to their 
 
 | Artifact | Location | Status | Notes |
 |----------|----------|--------|-------|
-| Builder Appointment | `modules/amc/10-builder-appointment/builder-appointment.md` | ⬜ Placeholder | Not started |
-| Builder Contract | `modules/amc/10-builder-appointment/builder-contract.md` | ⬜ Placeholder | Not started |
+| Builder Appointment | `modules/amc/10-builder-appointment/builder-appointment.md` | ⬜ Placeholder | Not started. |
+| Builder Contract | `modules/amc/10-builder-appointment/builder-contract.md` | ⬜ Placeholder | Not started. |
 
 ---
 
@@ -156,9 +168,9 @@ This index catalogs all pre-build artifacts for the AMC module, mapped to their 
 
 | Artifact | Location | Status | Notes |
 |----------|----------|--------|-------|
-| Build Evidence Index | `modules/amc/11-build/build-evidence-index.md` | ⬜ Placeholder | Not started |
-| QA-to-Green Evidence | `modules/amc/11-build/qa-to-green-evidence.md` | ⬜ Placeholder | Not started |
-| Handover | `modules/amc/11-build/handover.md` | ⬜ Placeholder | Not started |
+| Build Evidence Index | `modules/amc/11-build/build-evidence-index.md` | ⬜ Placeholder | Not started. |
+| QA-to-Green Evidence | `modules/amc/11-build/qa-to-green-evidence.md` | ⬜ Placeholder | Not started. |
+| Handover | `modules/amc/11-build/handover.md` | ⬜ Placeholder | Not started. |
 
 ---
 
@@ -170,4 +182,4 @@ This index catalogs all pre-build artifacts for the AMC module, mapped to their 
 
 ---
 
-**Legend**: ✅ Active/Complete | 🟡 Approval Pending | 🟠 Treated as Approved | 📌 Reference Only | ⬜ Placeholder/Not Started | 📦 Legacy Area
+**Legend**: ✅ Active/Complete | 🟡 Approval Pending / Retrofit Produced | 🟠 Treated as Approved | 📌 Reference Only | ⬜ Placeholder/Not Started | 📦 Legacy Area | ⛔ Superseded

--- a/modules/amc/BUILD_PROGRESS_TRACKER.md
+++ b/modules/amc/BUILD_PROGRESS_TRACKER.md
@@ -2,21 +2,23 @@
 
 **Module**: App Management Centre (AMC)  
 **Module Slug**: AMC  
-**Last Updated**: 2026-06-26  
-**Updated By**: foreman-v2-agent (wave: amc-stage5-functional-delivery-retrofit-20260626 — issue #1187; PR #1188; Stage 5 Architecture functional-delivery retrofit artifacts produced for CS2 review. Stage 5a, Stage 6, Stage 8, builder checklist, IAA pre-brief, builder appointment, and implementation remain blocked.)
+**Last Updated**: 2026-06-29  
+**Updated By**: foreman-v2-agent (wave: amc-stage5a-deployment-execution-retrofit-20260629 — issue #1189; PR #1190; Stage 5a Deployment Execution functional-delivery retrofit artifacts produced for CS2 review. Stage 6, Stage 7, Stage 8, builder checklist, IAA pre-brief, builder appointment, and implementation remain blocked.)
 
 > **Classification**: ACTIVE  
 > **Document Role**: PRIMARY LIVE CONTROL DOCUMENT — This is the designated primary operational monitor for AMC pre-build stage progress. CS2 should use this document as the main live progress dashboard.  
 > **Canon Reference**: `PRE_BUILD_STAGE_MODEL_CANON.md` v1.0.0 plus current ISMS/MMM functional-delivery retrofit lessons  
-> **Current Issue**: [app_management_centre#1187](https://github.com/APGI-cmy/app_management_centre/issues/1187)  
-> **Current PR**: [app_management_centre#1188](https://github.com/APGI-cmy/app_management_centre/pull/1188)  
+> **Current Issue**: [app_management_centre#1189](https://github.com/APGI-cmy/app_management_centre/issues/1189)  
+> **Current PR**: [app_management_centre#1190](https://github.com/APGI-cmy/app_management_centre/pull/1190)  
 > **Update Rule**: This document MUST be updated immediately after every AMC stage issue, wave completion, approval, or readiness/blocker change. Stale tracker text is a governance defect.
 
 > ⚠️ **GOVERNANCE OVERSIGHT NOTE (issue #1133, 2026-04-26)**: A mandatory deployment execution planning stage exists as Stage 5a between Stage 5 Architecture and Stage 6 QA-to-Red. Architecture/platform topology alone is insufficient. Stage 5a must remain separate and CS2-dispositioned before build execution can be considered.
 
 > ⚠️ **FUNCTIONAL DELIVERY RETROFIT NOTE (issue #1185, PR #1186, 2026-06-25)**: AMC Stages 1-4 were retrofitted with Stage 1 functional-delivery definition, Stage 2 CTA/API/Data/Audit matrix, Stage 3 FR-1900, Stage 4 TR-1900, and a Stage 1-4 change-propagation audit. Stages 5, 5a, 6, and 7 must import or explicitly disposition those obligations before Stage 8 may begin.
 
-> ⚠️ **STAGE 5 RETROFIT NOTE (issue #1187, PR #1188, 2026-06-26)**: Stage 5 Architecture has been reviewed against the merged Stage 1-4 retrofit. The wave produced a Stage 5 functional-delivery architecture addendum, a functional-delivery architecture map, and a Stage 5 change-propagation audit. This does not approve Stage 5 by itself and does not start Stage 5a, Stage 6, Stage 8, builder checklist, IAA pre-brief, builder appointment, or implementation.
+> ⚠️ **STAGE 5 RETROFIT NOTE (issue #1187, PR #1188, 2026-06-26)**: Stage 5 Architecture was reviewed against the merged Stage 1-4 retrofit. PR #1188 merged the Stage 5 functional-delivery architecture addendum, architecture map, change-propagation audit, architecture review notes, coverage note, and environment template. This does not start Stage 5a, Stage 6, Stage 8, builder checklist, IAA pre-brief, builder appointment, or implementation.
+
+> ⚠️ **STAGE 5A RETROFIT NOTE (issue #1189, PR #1190, 2026-06-29)**: Stage 5a Deployment Execution Strategy is being reviewed against the merged Stage 1-5 functional-delivery controls. The wave produced a Stage 5a functional-delivery deployment execution addendum, deployment execution validation matrix, and Stage 5a change-propagation audit. This does not start Stage 6, Stage 7, Stage 8, builder checklist, IAA pre-brief, builder appointment, or implementation.
 
 ---
 
@@ -31,15 +33,15 @@
 
 | Stage | Name | Status | Notes |
 |-------|------|--------|-------|
-| 1 | App Description | ✅ COMPLETE + 🟡 RETROFIT ADDENDUM PRODUCED | CS2-approved 2026-04-22. Functional-delivery addendum merged in #1186: `modules/amc/00-app-description/functional-delivery-definition.md`. |
-| 2 | UX Workflow & Wiring Spec | ✅ COMPLETE + 🟡 RETROFIT ADDENDUM PRODUCED | CS2-approved 2026-04-22. CTA/API/Data/Audit matrix merged in #1186: `modules/amc/01-ux-workflow-wiring-spec/cta-api-data-audit-contract-matrix.md`. Matrix must remain aligned with canonical TRS route/event contracts. |
-| 3 | FRS | ✅ COMPLETE — CS2 APPROVED + 🟡 RETROFIT ADDENDUM PRODUCED | CS2-approved for Stage 4 progression. FR-1900 merged in #1186: `modules/amc/02-frs/functional-delivery-requirements-addendum.md`. |
-| 4 | TRS | ✅ TREATED AS APPROVED + 🟡 RETROFIT ADDENDUM PRODUCED | Treated as approved for Stage 5 progression per #1131. TR-1900 merged in #1186: `modules/amc/03-trs/functional-delivery-technical-requirements-addendum.md`. |
+| 1 | App Description | ✅ COMPLETE + 🟡 RETROFIT ADDENDUM PRODUCED | CS2-approved 2026-04-22. Functional-delivery addendum merged in #1186. |
+| 2 | UX Workflow & Wiring Spec | ✅ COMPLETE + 🟡 RETROFIT ADDENDUM PRODUCED | CS2-approved 2026-04-22. CTA/API/Data/Audit matrix merged in #1186 and remains canonicalization-bound to TRS route/event contracts. |
+| 3 | FRS | ✅ COMPLETE — CS2 APPROVED + 🟡 RETROFIT ADDENDUM PRODUCED | FR-1900 merged in #1186. |
+| 4 | TRS | ✅ TREATED AS APPROVED + 🟡 RETROFIT ADDENDUM PRODUCED | TR-1900, including TR-1910, merged in #1186. |
 | 1-4 Retrofit | Functional Delivery Retrofit | ✅ MERGED / REFERENCE INPUT | PR #1186 merged. Stage 5/5a/6/7 must import or disposition its obligations. |
-| 5 | Architecture | 🟡 IN PROGRESS — RETROFIT PRODUCED FOR CS2 REVIEW | Existing Stage 5 Architecture Specification v1.0 remains produced approval-pending. PR #1188 adds Stage 5 functional-delivery addendum, architecture map, and change-propagation audit. |
-| **5a** | **Deployment Execution Strategy** | **🟡 PRODUCED APPROVAL-PENDING / NOT STARTED BY #1188** | Stage 5a artifacts exist but this wave does not review or approve them. Stage 5a must separately import/disposition TR-1910 before Stage 8. |
-| 6 | QA-to-Red | 🟡 PRODUCED APPROVAL-PENDING / NOT STARTED BY #1188 | Stage 6 must later import Stage 5 functional-delivery maps for RED tests. |
-| 7 | PBFAG | 🟡 PRODUCED APPROVAL-PENDING / NOT STARTED BY #1188 | Stage 7 must later import Stage 5 retrofit as a hard functional-delivery gate. |
+| 5 | Architecture | ✅ MERGED / REFERENCE INPUT | PR #1188 merged Stage 5 functional-delivery addendum, architecture map, change-propagation audit, review notes, coverage note, `.env.example`, tracker update, and wave record. |
+| **5a** | **Deployment Execution Strategy** | **🟡 IN PROGRESS — RETROFIT PRODUCED FOR CS2 REVIEW** | Existing Stage 5a DES pack remains produced approval-pending. PR #1190 adds Stage 5a functional-delivery addendum, validation matrix, and change-propagation audit. |
+| 6 | QA-to-Red | 🟡 PRODUCED APPROVAL-PENDING / NOT STARTED BY #1190 | Stage 6 must later import Stage 5 and Stage 5a functional-delivery maps for RED tests. |
+| 7 | PBFAG | 🟡 PRODUCED APPROVAL-PENDING / NOT STARTED BY #1190 | Stage 7 must later import Stage 5/5a retrofit as hard functional-delivery and deployment-execution gates. |
 | 8 | Implementation Plan | ⬜ Not Started | 🔴 BLOCKED — must not start until Stages 5, 5a, 6, 7 and retrofit obligations are CS2-dispositioned/imported. |
 | 9 | Builder Checklist | ⬜ Not Started | 🔴 BLOCKED |
 | 10 | IAA Pre-Brief | ⬜ Not Started | 🔴 BLOCKED |
@@ -98,48 +100,53 @@
 
 ### Stage 5 — Architecture
 
-**Status**: 🟡 IN PROGRESS — RETROFIT PRODUCED FOR CS2 REVIEW  
+**Status**: ✅ MERGED AS RETROFIT REFERENCE INPUT  
 **Location**: `modules/amc/04-architecture/`  
 **Key Artifacts**:
-- [x] `architecture-specification.md` — Stage 5 Architecture Specification v1.0 (produced 2026-04-26; approval-pending)
+- [x] `architecture-specification.md`
 - [x] `trs-to-architecture-traceability.md`
-- [x] `functional-delivery-architecture-addendum.md` — produced in issue #1187 / PR #1188
-- [x] `functional-delivery-architecture-map.md` — produced in issue #1187 / PR #1188
-- [x] `stage5-functional-delivery-change-propagation-audit.md` — produced in issue #1187 / PR #1188
+- [x] `functional-delivery-architecture-addendum.md`
+- [x] `functional-delivery-architecture-map.md`
+- [x] `stage5-functional-delivery-change-propagation-audit.md`
+- [x] `stage5-review-notes.md`
+- [x] `extra-review-note.md`
 
-**Current gate note**: Stage 5 can only be dispositioned after CS2 reviews the original architecture together with the Stage 5 functional-delivery addendum, architecture map, and change-propagation audit. This tracker update does not approve Stage 5.
+**Current gate note**: Stage 5 is now a merged reference input for Stage 5a/6/7 propagation. This does not authorize implementation.
 
 ---
 
 ### Stage 5a — Deployment Execution Strategy
 
-**Status**: 🟡 PRODUCED APPROVAL-PENDING; not started by #1188  
+**Status**: 🟡 IN PROGRESS — RETROFIT PRODUCED FOR CS2 REVIEW  
 **Location**: `modules/amc/05a-deployment-execution-strategy/`  
 **Key Artifacts**:
 - [x] `deployment-execution-strategy.md`
 - [x] `deployment-surface-ownership-table.md`
 - [x] `runner-and-environment-constraints.md`
+- [x] `functional-delivery-deployment-execution-addendum.md` — produced in issue #1189 / PR #1190
+- [x] `deployment-execution-validation-matrix.md` — produced in issue #1189 / PR #1190
+- [x] `stage5a-functional-delivery-change-propagation-audit.md` — produced in issue #1189 / PR #1190
 
-**Current gate note**: Stage 5a remains separate and must later import/disposition TR-1910 and deployment-execution no-speculation controls. PR #1188 does not start or approve Stage 5a.
+**Current gate note**: Stage 5a can only be dispositioned after CS2 reviews the existing DES pack together with the Stage 5a retrofit addendum, validation matrix, and change-propagation audit. This tracker update does not approve Stage 5a.
 
 ---
 
 ### Stage 6 — QA-to-Red
 
-**Status**: 🟡 PRODUCED APPROVAL-PENDING; not started by #1188  
+**Status**: 🟡 PRODUCED APPROVAL-PENDING; not started by #1190  
 **Location**: `modules/amc/05-qa-to-red/`  
 **Key Artifacts**:
 - [x] `qa-to-red-specification.md`
 - [x] `architecture-and-des-to-qa-traceability.md`
 - [x] `red-test-catalog.md`
 
-**Current gate note**: Stage 6 must later import Stage 5 route/action/state/audit/degraded-mode maps and create RED tests for dead CTA, missing backend, missing audit, authority bypass, degraded-mode, placeholder leakage, route/event drift, and journey-level completion.
+**Current gate note**: Stage 6 must later import Stage 5 route/action/state/audit/degraded-mode maps and Stage 5a deployment-execution validation obligations.
 
 ---
 
 ### Stage 7 — PBFAG
 
-**Status**: 🟡 PRODUCED APPROVAL-PENDING; not started by #1188  
+**Status**: 🟡 PRODUCED APPROVAL-PENDING; not started by #1190  
 **Location**: `modules/amc/06-pbfag/`  
 **Key Artifacts**:
 - [x] `pre-build-final-assurance-gate.md`
@@ -148,7 +155,7 @@
 - [x] `pbfag-checklist.md`
 - [x] `stage1-4-functional-delivery-change-propagation-audit.md`
 
-**Current gate note**: Stage 7 must later import the Stage 5 retrofit and fail/condition Stage 8 if material action coverage, route/event authority, deployment execution, or placeholder controls remain unresolved.
+**Current gate note**: Stage 7 must later import Stage 5/5a retrofit and fail/condition Stage 8 if material action coverage, deployment execution, route/event authority, evidence package, or placeholder controls remain unresolved.
 
 ---
 
@@ -156,7 +163,7 @@
 
 **Status**: ⬜ Not Started  
 **Location**: `modules/amc/07-implementation-plan/`  
-**Current blocker**: Stage 8 remains blocked. PR #1188 does not start Stage 8.
+**Current blocker**: Stage 8 remains blocked. PR #1190 does not start Stage 8.
 
 ---
 
@@ -188,15 +195,15 @@
 
 **Status**: ⬜ Not Started  
 **Location**: `modules/amc/11-build/`  
-**Current blocker**: Build remains blocked. PR #1188 does not authorize implementation.
+**Current blocker**: Build remains blocked. PR #1190 does not authorize implementation.
 
 ---
 
 ## Next Action
 
-1. Review PR #1188 for Stage 5 functional-delivery architecture alignment.
-2. CS2 to disposition whether original Stage 5 Architecture may be approved with the Stage 5 addendum, map, and audit attached.
-3. Do not start Stage 5a, Stage 6, or Stage 8 from this PR.
+1. Review PR #1190 for Stage 5a deployment-execution functional-delivery alignment.
+2. CS2 to disposition whether the existing Stage 5a DES pack may be approved with the Stage 5a addendum, validation matrix, and audit attached.
+3. Do not start Stage 6, Stage 7, or Stage 8 from this PR.
 4. Do not appoint builders until the canonical pre-build sequence authorizes Stage 11.
 
 ---
@@ -208,8 +215,11 @@
 - [cta-api-data-audit-contract-matrix.md](./01-ux-workflow-wiring-spec/cta-api-data-audit-contract-matrix.md)
 - [functional-delivery-requirements-addendum.md](./02-frs/functional-delivery-requirements-addendum.md)
 - [functional-delivery-technical-requirements-addendum.md](./03-trs/functional-delivery-technical-requirements-addendum.md)
-- [architecture-specification.md](./04-architecture/architecture-specification.md)
 - [functional-delivery-architecture-addendum.md](./04-architecture/functional-delivery-architecture-addendum.md)
 - [functional-delivery-architecture-map.md](./04-architecture/functional-delivery-architecture-map.md)
-- [stage5-functional-delivery-change-propagation-audit.md](./04-architecture/stage5-functional-delivery-change-propagation-audit.md)
-- [stage1-4-functional-delivery-change-propagation-audit.md](./06-pbfag/stage1-4-functional-delivery-change-propagation-audit.md)
+- [deployment-execution-strategy.md](./05a-deployment-execution-strategy/deployment-execution-strategy.md)
+- [deployment-surface-ownership-table.md](./05a-deployment-execution-strategy/deployment-surface-ownership-table.md)
+- [runner-and-environment-constraints.md](./05a-deployment-execution-strategy/runner-and-environment-constraints.md)
+- [functional-delivery-deployment-execution-addendum.md](./05a-deployment-execution-strategy/functional-delivery-deployment-execution-addendum.md)
+- [deployment-execution-validation-matrix.md](./05a-deployment-execution-strategy/deployment-execution-validation-matrix.md)
+- [stage5a-functional-delivery-change-propagation-audit.md](./05a-deployment-execution-strategy/stage5a-functional-delivery-change-propagation-audit.md)

--- a/modules/amc/BUILD_PROGRESS_TRACKER.md
+++ b/modules/amc/BUILD_PROGRESS_TRACKER.md
@@ -3,7 +3,7 @@
 **Module**: App Management Centre (AMC)  
 **Module Slug**: AMC  
 **Last Updated**: 2026-06-29  
-**Updated By**: foreman-v2-agent (wave: amc-stage5a-deployment-execution-retrofit-20260629 — issue #1189; PR #1190; Stage 5a Deployment Execution functional-delivery retrofit artifacts produced for CS2 review. Stage 6, Stage 7, Stage 8, builder checklist, IAA pre-brief, builder appointment, and implementation remain blocked.)
+**Updated By**: foreman-v2-agent (wave: amc-stage5a-deployment-execution-retrofit-20260629 — issue #1189; PR #1190; Stage 5a Deployment Execution functional-delivery retrofit artifacts produced for CS2 review. Stage 5 remains approval-pending with merged retrofit inputs. Stage 6, Stage 7, Stage 8, builder checklist, IAA pre-brief, builder appointment, and implementation remain blocked.)
 
 > **Classification**: ACTIVE  
 > **Document Role**: PRIMARY LIVE CONTROL DOCUMENT — This is the designated primary operational monitor for AMC pre-build stage progress. CS2 should use this document as the main live progress dashboard.  
@@ -16,7 +16,7 @@
 
 > ⚠️ **FUNCTIONAL DELIVERY RETROFIT NOTE (issue #1185, PR #1186, 2026-06-25)**: AMC Stages 1-4 were retrofitted with Stage 1 functional-delivery definition, Stage 2 CTA/API/Data/Audit matrix, Stage 3 FR-1900, Stage 4 TR-1900, and a Stage 1-4 change-propagation audit. Stages 5, 5a, 6, and 7 must import or explicitly disposition those obligations before Stage 8 may begin.
 
-> ⚠️ **STAGE 5 RETROFIT NOTE (issue #1187, PR #1188, 2026-06-26)**: Stage 5 Architecture was reviewed against the merged Stage 1-4 retrofit. PR #1188 merged the Stage 5 functional-delivery architecture addendum, architecture map, change-propagation audit, architecture review notes, coverage note, and environment template. This does not start Stage 5a, Stage 6, Stage 8, builder checklist, IAA pre-brief, builder appointment, or implementation.
+> ⚠️ **STAGE 5 RETROFIT NOTE (issue #1187, PR #1188, 2026-06-26)**: Stage 5 Architecture was reviewed against the merged Stage 1-4 retrofit. PR #1188 merged Stage 5 functional-delivery retrofit inputs. Stage 5 remains approval-pending until CS2 disposition of the original architecture plus the retrofit package. This does not start Stage 5a, Stage 6, Stage 8, builder checklist, IAA pre-brief, builder appointment, or implementation.
 
 > ⚠️ **STAGE 5A RETROFIT NOTE (issue #1189, PR #1190, 2026-06-29)**: Stage 5a Deployment Execution Strategy is being reviewed against the merged Stage 1-5 functional-delivery controls. The wave produced a Stage 5a functional-delivery deployment execution addendum, deployment execution validation matrix, and Stage 5a change-propagation audit. This does not start Stage 6, Stage 7, Stage 8, builder checklist, IAA pre-brief, builder appointment, or implementation.
 
@@ -38,8 +38,8 @@
 | 3 | FRS | ✅ COMPLETE — CS2 APPROVED + 🟡 RETROFIT ADDENDUM PRODUCED | FR-1900 merged in #1186. |
 | 4 | TRS | ✅ TREATED AS APPROVED + 🟡 RETROFIT ADDENDUM PRODUCED | TR-1900, including TR-1910, merged in #1186. |
 | 1-4 Retrofit | Functional Delivery Retrofit | ✅ MERGED / REFERENCE INPUT | PR #1186 merged. Stage 5/5a/6/7 must import or disposition its obligations. |
-| 5 | Architecture | ✅ MERGED / REFERENCE INPUT | PR #1188 merged Stage 5 functional-delivery addendum, architecture map, change-propagation audit, review notes, coverage note, `.env.example`, tracker update, and wave record. |
-| **5a** | **Deployment Execution Strategy** | **🟡 IN PROGRESS — RETROFIT PRODUCED FOR CS2 REVIEW** | Existing Stage 5a DES pack remains produced approval-pending. PR #1190 adds Stage 5a functional-delivery addendum, validation matrix, and change-propagation audit. |
+| 5 | Architecture | 🟡 APPROVAL-PENDING / RETROFIT MERGED AS REFERENCE INPUT | Original Stage 5 Architecture remains approval-pending. PR #1188 merged retrofit inputs for CS2 disposition; merge is not Stage 5 approval. |
+| **5a** | **Deployment Execution Strategy** | **🟡 IN PROGRESS — RETROFIT PRODUCED FOR CS2 REVIEW** | Existing Stage 5a DES pack remains produced approval-pending. PR #1190 adds Stage 5a functional-delivery addendum, validation matrix, artifact-index reconciliation, and change-propagation audit. |
 | 6 | QA-to-Red | 🟡 PRODUCED APPROVAL-PENDING / NOT STARTED BY #1190 | Stage 6 must later import Stage 5 and Stage 5a functional-delivery maps for RED tests. |
 | 7 | PBFAG | 🟡 PRODUCED APPROVAL-PENDING / NOT STARTED BY #1190 | Stage 7 must later import Stage 5/5a retrofit as hard functional-delivery and deployment-execution gates. |
 | 8 | Implementation Plan | ⬜ Not Started | 🔴 BLOCKED — must not start until Stages 5, 5a, 6, 7 and retrofit obligations are CS2-dispositioned/imported. |
@@ -48,7 +48,7 @@
 | 11 | Builder Appointment | ⬜ Not Started | 🔴 BLOCKED — no builders appointed. |
 | 12 | Build | ⬜ Not Started | 🔴 BLOCKED — no implementation/build authorization. |
 
-**Legend**: ✅ Complete | 🟡 Active / Produced / In Progress | ⬜ Not Started | 🔴 Blocked
+**Legend**: ✅ Complete | 🟡 Active / Produced / In Progress / Approval-Pending | ⬜ Not Started | 🔴 Blocked
 
 ---
 
@@ -100,18 +100,18 @@
 
 ### Stage 5 — Architecture
 
-**Status**: ✅ MERGED AS RETROFIT REFERENCE INPUT  
+**Status**: 🟡 APPROVAL-PENDING — RETROFIT MERGED AS REFERENCE INPUT  
 **Location**: `modules/amc/04-architecture/`  
 **Key Artifacts**:
-- [x] `architecture-specification.md`
-- [x] `trs-to-architecture-traceability.md`
-- [x] `functional-delivery-architecture-addendum.md`
-- [x] `functional-delivery-architecture-map.md`
-- [x] `stage5-functional-delivery-change-propagation-audit.md`
-- [x] `stage5-review-notes.md`
-- [x] `extra-review-note.md`
+- [x] `architecture-specification.md` — Stage 5 Architecture Specification v1.0 remains approval-pending.
+- [x] `trs-to-architecture-traceability.md` — remains approval-pending with Stage 5.
+- [x] `functional-delivery-architecture-addendum.md` — merged in PR #1188 as retrofit input.
+- [x] `functional-delivery-architecture-map.md` — merged in PR #1188 as retrofit input.
+- [x] `stage5-functional-delivery-change-propagation-audit.md` — merged in PR #1188 as retrofit input.
+- [x] `stage5-review-notes.md` — merged in PR #1188 as retrofit input.
+- [x] `extra-review-note.md` — merged in PR #1188 as retrofit input.
 
-**Current gate note**: Stage 5 is now a merged reference input for Stage 5a/6/7 propagation. This does not authorize implementation.
+**Current gate note**: Stage 5 is a merged reference input for Stage 5a/6/7 propagation, but it is not marked CS2-approved by tracker. Stage 5 still requires CS2 disposition of the original architecture together with the retrofit package. This does not authorize implementation.
 
 ---
 
@@ -127,7 +127,7 @@
 - [x] `deployment-execution-validation-matrix.md` — produced in issue #1189 / PR #1190
 - [x] `stage5a-functional-delivery-change-propagation-audit.md` — produced in issue #1189 / PR #1190
 
-**Current gate note**: Stage 5a can only be dispositioned after CS2 reviews the existing DES pack together with the Stage 5a retrofit addendum, validation matrix, and change-propagation audit. This tracker update does not approve Stage 5a.
+**Current gate note**: Stage 5a can only be dispositioned after CS2 reviews the existing DES pack together with the Stage 5a retrofit addendum, validation matrix, artifact-index reconciliation, and change-propagation audit. This tracker update does not approve Stage 5a.
 
 ---
 
@@ -202,7 +202,7 @@
 ## Next Action
 
 1. Review PR #1190 for Stage 5a deployment-execution functional-delivery alignment.
-2. CS2 to disposition whether the existing Stage 5a DES pack may be approved with the Stage 5a addendum, validation matrix, and audit attached.
+2. CS2 to disposition whether the existing Stage 5a DES pack may be approved with the Stage 5a addendum, validation matrix, artifact-index reconciliation, and audit attached.
 3. Do not start Stage 6, Stage 7, or Stage 8 from this PR.
 4. Do not appoint builders until the canonical pre-build sequence authorizes Stage 11.
 
@@ -223,3 +223,4 @@
 - [functional-delivery-deployment-execution-addendum.md](./05a-deployment-execution-strategy/functional-delivery-deployment-execution-addendum.md)
 - [deployment-execution-validation-matrix.md](./05a-deployment-execution-strategy/deployment-execution-validation-matrix.md)
 - [stage5a-functional-delivery-change-propagation-audit.md](./05a-deployment-execution-strategy/stage5a-functional-delivery-change-propagation-audit.md)
+- [AMC_PRE_BUILD_ARTIFACT_INDEX.md](./AMC_PRE_BUILD_ARTIFACT_INDEX.md)

--- a/modules/amc/BUILD_PROGRESS_TRACKER.md
+++ b/modules/amc/BUILD_PROGRESS_TRACKER.md
@@ -211,12 +211,15 @@
 ## References
 
 - [PRE_BUILD_STAGE_MODEL_CANON.md](../../governance/canon/PRE_BUILD_STAGE_MODEL_CANON.md)
+- [architecture-specification.md](./04-architecture/architecture-specification.md)
 - [functional-delivery-definition.md](./00-app-description/functional-delivery-definition.md)
 - [cta-api-data-audit-contract-matrix.md](./01-ux-workflow-wiring-spec/cta-api-data-audit-contract-matrix.md)
 - [functional-delivery-requirements-addendum.md](./02-frs/functional-delivery-requirements-addendum.md)
 - [functional-delivery-technical-requirements-addendum.md](./03-trs/functional-delivery-technical-requirements-addendum.md)
 - [functional-delivery-architecture-addendum.md](./04-architecture/functional-delivery-architecture-addendum.md)
 - [functional-delivery-architecture-map.md](./04-architecture/functional-delivery-architecture-map.md)
+- [stage1-4-functional-delivery-change-propagation-audit.md](./06-pbfag/stage1-4-functional-delivery-change-propagation-audit.md)
+- [stage5-functional-delivery-change-propagation-audit.md](./04-architecture/stage5-functional-delivery-change-propagation-audit.md)
 - [deployment-execution-strategy.md](./05a-deployment-execution-strategy/deployment-execution-strategy.md)
 - [deployment-surface-ownership-table.md](./05a-deployment-execution-strategy/deployment-surface-ownership-table.md)
 - [runner-and-environment-constraints.md](./05a-deployment-execution-strategy/runner-and-environment-constraints.md)


### PR DESCRIPTION
## Summary

governing_issue: #1189

This PR opens the AMC Stage 5a Deployment Execution Functional Delivery Retrofit wave requested in issue #1189.

It reviews the existing Stage 5a Deployment Execution Strategy against the merged Stage 1-4 functional-delivery retrofit from PR #1186 and the merged Stage 5 Architecture retrofit from PR #1188.

## Added / updated artifacts

1. `modules/amc/05a-deployment-execution-strategy/functional-delivery-deployment-execution-addendum.md`
   - Imports TR-1910, the Stage 5 architecture map, deployment evidence expectations, runtime health/smoke validation, dependency readiness, and no-operational-speculation controls into Stage 5a.

2. `modules/amc/05a-deployment-execution-strategy/deployment-execution-validation-matrix.md`
   - Adds workflow, environment, migration, protected approval, health, rollback, dependency, audit, and evidence validation obligations for Stage 6/7 derivation.

3. `modules/amc/05a-deployment-execution-strategy/stage5a-functional-delivery-change-propagation-audit.md`
   - Records CLEAN / ADVISORY / DRIFT / AMBIGUITY findings for Stage 5a against the merged Stage 1-5 retrofit.

4. `modules/amc/BUILD_PROGRESS_TRACKER.md`
   - Updates the primary live tracker to record issue #1189 / PR #1190 and the current Stage 5a retrofit status.

5. `.agent-admin/wave-records/amc-wave-record-1190-current.md`
   - Records the Stage 5a retrofit wave without invoking a prehandover lane or claiming handover authorization.

## Governance constraints

- Does not approve Stage 5a.
- Does not start Stage 6.
- Does not start Stage 7.
- Does not start Stage 8.
- Does not create builder checklist.
- Does not create IAA pre-brief.
- Does not appoint builders.
- Does not authorize implementation work.
- Does not certify AMC build-readiness.

## Key findings

- Existing Stage 5a DES pack is structurally strong and not rejected.
- Existing Stage 5a predates the merged Stage 5 functional-delivery architecture package and therefore needed explicit import/disposition controls.
- The retrofit adds deploy-time validation and evidence requirements for workflow ownership, protected environments, migrations, rollback, runtime health, external dependency readiness, audit/provenance, and the first E2E evidence candidate.
- Stage 6 and Stage 7 must import this retrofit before Stage 8 may be considered.

## Review focus

Please review whether the Stage 5a package now gives Stage 6 QA-to-Red and Stage 7 PBFAG enough deployment-execution clarity to prevent operational speculation, missing evidence, unsafe migration behavior, secret-boundary drift, and unvalidated runtime claims.

Closes #1189 only after CS2 disposition and tracker/artifact-index reconciliation are completed; this PR currently produces the Stage 5a retrofit artifacts for review.