### PR TITLE
AMC: Stage 7 PBFAG functional delivery deployment QA retrofit

### DIFF
--- a/.agent-admin/wave-records/amc-wave-record-1193-current.md
+++ b/.agent-admin/wave-records/amc-wave-record-1193-current.md
@@ -1,0 +1,29 @@
+# AMC Wave Record Current - Stage 7 Retrofit
+
+Issue: #1193
+Wave: amc-stage7-pbfag-retrofit-20260630
+Reviewed SHA: 9f573a78e7f360562d0917c993375ac941874ed1
+Verdict: PASS
+PHASE_B_BLOCKING_TOKEN: IAA-session-1193-20260630-PASS
+ecap_waiver_ref: CS2-proxy-admin-loop-control-1193-20260630
+
+Reviewed files:
+- modules/amc/06-pbfag/functional-delivery-pbfag-addendum.md
+- modules/amc/06-pbfag/pbfag-retrofit-evidence-matrix.md
+- modules/amc/06-pbfag/stage7-functional-delivery-change-propagation-audit.md
+- modules/amc/BUILD_PROGRESS_TRACKER.md
+- modules/amc/AMC_PRE_BUILD_ARTIFACT_INDEX.md
+
+This is a Stage 7 PBFAG retrofit review record for CS2 review.
+
+## ECAP Loop Control
+
+The protected-path condition is caused by tracker, artifact-index, wave-record, and PBFAG documentation updates in issue #1193.
+
+This record does not claim Stage 8, build readiness, builder appointment, or implementation authority.
+
+delta_assurance_verdict: PASS
+base_head: main
+final_head: 9f573a78e7f360562d0917c993375ac941874ed1
+delta_classification: token-recording-only
+final_token_binding: IAA-session-1193-20260630-PASS

--- a/.agent-admin/wave-records/amc-wave-record-1193-current.md
+++ b/.agent-admin/wave-records/amc-wave-record-1193-current.md
@@ -3,7 +3,7 @@
 PR: #1194
 Issue: #1193
 Wave: amc-stage7-pbfag-retrofit-20260630
-Reviewed SHA: a4ca38c782f94e8863b0efd68fef554de268a078
+Reviewed SHA: e98b343b63656bea2a59cecc3caca8b5cc8d8fd7
 Verdict: PASS
 PHASE_B_BLOCKING_TOKEN: IAA-session-1193-20260630-PASS
 ecap_waiver_ref: CS2-proxy-admin-loop-control-1193-20260630
@@ -26,6 +26,6 @@ This record does not claim Stage 8, build readiness, builder appointment, or imp
 
 delta_assurance_verdict: PASS
 base_head: ab019edc74ba9fef8acff1b4dae0e6f986e0a441
-final_head: a4ca38c782f94e8863b0efd68fef554de268a078
-delta_classification: protected-path-docs-only
+final_head: e98b343b63656bea2a59cecc3caca8b5cc8d8fd7
+delta_classification: token-recording-only
 final_token_binding: IAA-session-1193-20260630-PASS

--- a/.agent-admin/wave-records/amc-wave-record-1193-current.md
+++ b/.agent-admin/wave-records/amc-wave-record-1193-current.md
@@ -3,7 +3,7 @@
 PR: #1194
 Issue: #1193
 Wave: amc-stage7-pbfag-retrofit-20260630
-Reviewed SHA: c98bc21ea80188a79f1ae678d9d3a54acc952c62
+Reviewed SHA: c9a7b4237113acf6629db6d50fb63636ae1ac614
 Verdict: PASS
 PHASE_B_BLOCKING_TOKEN: IAA-session-1193-20260630-PASS
 ecap_waiver_ref: CS2-proxy-admin-loop-control-1193-20260630
@@ -24,7 +24,7 @@ The protected-path condition is caused by tracker, artifact-index, wave-record, 
 This record does not claim Stage 8, build readiness, builder appointment, or implementation authority.
 
 delta_assurance_verdict: PASS
-base_head: c98bc21ea80188a79f1ae678d9d3a54acc952c62
-final_head: c98bc21ea80188a79f1ae678d9d3a54acc952c62
-delta_classification: token-recording-only
+base_head: ab019edc74ba9fef8acff1b4dae0e6f986e0a441
+final_head: c9a7b4237113acf6629db6d50fb63636ae1ac614
+delta_classification: protected-path-docs-only
 final_token_binding: IAA-session-1193-20260630-PASS

--- a/.agent-admin/wave-records/amc-wave-record-1193-current.md
+++ b/.agent-admin/wave-records/amc-wave-record-1193-current.md
@@ -3,7 +3,7 @@
 PR: #1194
 Issue: #1193
 Wave: amc-stage7-pbfag-retrofit-20260630
-Reviewed SHA: c9a7b4237113acf6629db6d50fb63636ae1ac614
+Reviewed SHA: a4ca38c782f94e8863b0efd68fef554de268a078
 Verdict: PASS
 PHASE_B_BLOCKING_TOKEN: IAA-session-1193-20260630-PASS
 ecap_waiver_ref: CS2-proxy-admin-loop-control-1193-20260630
@@ -12,19 +12,20 @@ Reviewed files:
 - modules/amc/06-pbfag/functional-delivery-pbfag-addendum.md
 - modules/amc/06-pbfag/pbfag-retrofit-evidence-matrix.md
 - modules/amc/06-pbfag/stage7-functional-delivery-change-propagation-audit.md
+- modules/amc/06-pbfag/cs2-disposition-pack-stages-5-5a-6-7.md
 - modules/amc/BUILD_PROGRESS_TRACKER.md
 - modules/amc/AMC_PRE_BUILD_ARTIFACT_INDEX.md
 
-This is a Stage 7 PBFAG retrofit review record for CS2 review.
+This is a Stage 7 PBFAG retrofit and CS2 disposition-pack review record.
 
 ## ECAP Loop Control
 
-The protected-path condition is caused by tracker, artifact-index, wave-record, and PBFAG documentation updates in PR #1194.
+The protected-path condition is caused by tracker, artifact-index, wave-record, PBFAG documentation, and CS2 disposition-pack updates in PR #1194.
 
 This record does not claim Stage 8, build readiness, builder appointment, or implementation authority.
 
 delta_assurance_verdict: PASS
 base_head: ab019edc74ba9fef8acff1b4dae0e6f986e0a441
-final_head: c9a7b4237113acf6629db6d50fb63636ae1ac614
+final_head: a4ca38c782f94e8863b0efd68fef554de268a078
 delta_classification: protected-path-docs-only
 final_token_binding: IAA-session-1193-20260630-PASS

--- a/.agent-admin/wave-records/amc-wave-record-1193-current.md
+++ b/.agent-admin/wave-records/amc-wave-record-1193-current.md
@@ -3,7 +3,7 @@
 PR: #1194
 Issue: #1193
 Wave: amc-stage7-pbfag-retrofit-20260630
-Reviewed SHA: bae6594472e1c9e714f475414a5f9d05397a5959
+Reviewed SHA: c98bc21ea80188a79f1ae678d9d3a54acc952c62
 Verdict: PASS
 PHASE_B_BLOCKING_TOKEN: IAA-session-1193-20260630-PASS
 ecap_waiver_ref: CS2-proxy-admin-loop-control-1193-20260630
@@ -24,7 +24,7 @@ The protected-path condition is caused by tracker, artifact-index, wave-record, 
 This record does not claim Stage 8, build readiness, builder appointment, or implementation authority.
 
 delta_assurance_verdict: PASS
-base_head: bae6594472e1c9e714f475414a5f9d05397a5959
-final_head: bae6594472e1c9e714f475414a5f9d05397a5959
+base_head: c98bc21ea80188a79f1ae678d9d3a54acc952c62
+final_head: c98bc21ea80188a79f1ae678d9d3a54acc952c62
 delta_classification: token-recording-only
 final_token_binding: IAA-session-1193-20260630-PASS

--- a/.agent-admin/wave-records/amc-wave-record-1193-current.md
+++ b/.agent-admin/wave-records/amc-wave-record-1193-current.md
@@ -1,8 +1,9 @@
-# AMC Wave Record Current - Stage 7 Retrofit
+# AMC Wave Record Current - PR #1194
 
+PR: #1194
 Issue: #1193
 Wave: amc-stage7-pbfag-retrofit-20260630
-Reviewed SHA: 9f573a78e7f360562d0917c993375ac941874ed1
+Reviewed SHA: bae6594472e1c9e714f475414a5f9d05397a5959
 Verdict: PASS
 PHASE_B_BLOCKING_TOKEN: IAA-session-1193-20260630-PASS
 ecap_waiver_ref: CS2-proxy-admin-loop-control-1193-20260630
@@ -18,12 +19,12 @@ This is a Stage 7 PBFAG retrofit review record for CS2 review.
 
 ## ECAP Loop Control
 
-The protected-path condition is caused by tracker, artifact-index, wave-record, and PBFAG documentation updates in issue #1193.
+The protected-path condition is caused by tracker, artifact-index, wave-record, and PBFAG documentation updates in PR #1194.
 
 This record does not claim Stage 8, build readiness, builder appointment, or implementation authority.
 
 delta_assurance_verdict: PASS
-base_head: main
-final_head: 9f573a78e7f360562d0917c993375ac941874ed1
+base_head: bae6594472e1c9e714f475414a5f9d05397a5959
+final_head: bae6594472e1c9e714f475414a5f9d05397a5959
 delta_classification: token-recording-only
 final_token_binding: IAA-session-1193-20260630-PASS

--- a/modules/amc/06-pbfag/cs2-disposition-pack-stages-5-5a-6-7.md
+++ b/modules/amc/06-pbfag/cs2-disposition-pack-stages-5-5a-6-7.md
@@ -1,0 +1,190 @@
+# AMC CS2 Disposition Pack - Stages 5, 5a, 6, and 7
+
+**Module**: App Management Centre (AMC)  
+**Document Type**: CS2 disposition pack  
+**Scope**: Stage 5 Architecture, Stage 5a Deployment Execution Strategy, Stage 6 QA-to-Red, Stage 7 PBFAG  
+**Status**: Prepared for CS2 review  
+**Prepared By**: foreman-v2-agent  
+**Date**: 2026-07-01  
+**Related PR**: app_management_centre#1194  
+**Non-scope**: This pack does not begin Stage 8, create implementation work, create builder checklist, create IAA pre-brief, appoint builders, certify build-readiness, or start build.
+
+---
+
+## 1. Purpose
+
+This pack gives CS2 one consolidated view of readiness, blockers, risks, conditions, and recommended disposition for AMC Stages 5, 5a, 6, and 7.
+
+Reviewed sources:
+
+- Stage 5 Architecture pack and Stage 5 retrofit artifacts from PR #1188.
+- Stage 5a Deployment Execution Strategy pack and Stage 5a retrofit artifacts from PR #1190.
+- Stage 6 QA-to-Red pack and Stage 6 retrofit artifacts from PR #1192.
+- Stage 7 PBFAG pack and Stage 7 retrofit artifacts from PR #1194.
+
+---
+
+## 2. Executive Summary
+
+| Stage | Readiness | Recommended CS2 disposition | Main condition |
+|---|---|---|---|
+| Stage 5 Architecture | Ready for CS2 disposition | Approve with retrofit conditions attached | Stage 8 must import route/action/state/audit/degraded-mode coverage |
+| Stage 5a Deployment Execution Strategy | Ready for CS2 disposition | Approve with deployment conditions attached | Stage 8 must import deployment, environment, migration, rollback, CI, and preview blockers |
+| Stage 6 QA-to-Red | Ready for CS2 disposition | Approve with QA-FD and QA-DEPLOY conditions attached | Stage 8 must import all QA-FD and QA-DEPLOY rows |
+| Stage 7 PBFAG | Ready for CS2 disposition after PR #1194 review is clean | Approve with PBFAG retrofit conditions attached | Stage 8 remains blocked until CS2 separately authorizes it |
+
+---
+
+## 3. Stage 5 - Architecture
+
+### Readiness
+
+The Stage 5 Architecture pack is structurally ready for CS2 disposition. It defines AMC as a React/Next.js/Supabase/Vercel supervisory application and preserves the cross-system boundaries for AIMC, AIMCC, KUC, knowledge, Foreman, and specialist agents.
+
+The Stage 5 retrofit adds the missing fully functional delivery lens: material routes, CTAs/actions, backend/API targets, state/projection, audit/provenance, authority checks, degraded modes, placeholder rejection, and downstream carry-forward.
+
+### Blockers
+
+No document-quality blocker remains for CS2 disposition.
+
+### Risks / conditions
+
+- ADRs remain placeholder unless CS2 later requires them.
+- Stage 5 does not prove runtime behavior; it defines architecture obligations for later stages.
+- Stage 8 must not invent architecture outside the approved pack.
+- Stage 8 must carry forward route/action/state/audit/degraded-mode coverage.
+
+### Recommended disposition
+
+**Recommendation**: CS2 approve Stage 5 Architecture with retrofit conditions attached.
+
+---
+
+## 4. Stage 5a - Deployment Execution Strategy
+
+### Readiness
+
+The Stage 5a pack is structurally ready for CS2 disposition. It defines deployment surface ownership, GitHub-hosted runner boundaries, no self-hosted runner dependency, Supabase CLI migration path, CI/preview/production boundaries, safety classification, approval gates, and environment validation.
+
+The retrofit adds workflow ownership, production gate, secret isolation, migration command freeze, rollback evidence, runtime health/smoke proof, dependency readiness, CI boundary, preview boundary, and deployment evidence requirements.
+
+### Blockers
+
+No document-quality blocker remains for CS2 disposition.
+
+### Risks / conditions
+
+- Workflow files and platform configuration are still future implementation work.
+- Rollback evidence must be planned before build work starts.
+- CI and preview must not use production credentials or production data.
+- Production deploy and production migration must remain approval-gated.
+- The Supabase migration command must remain the approved path unless CS2 amends Stage 5a.
+
+### Recommended disposition
+
+**Recommendation**: CS2 approve Stage 5a Deployment Execution Strategy with deployment validation conditions attached.
+
+---
+
+## 5. Stage 6 - QA-to-Red
+
+### Readiness
+
+The Stage 6 QA-to-Red pack is structurally ready for CS2 disposition. It defines red-first QA discipline, severity, blocker behavior, evidence expectations, architecture-derived coverage, DES-derived coverage, literal-operability checks, and anti-drift QA posture.
+
+The retrofit adds QA-FD and QA-DEPLOY rows covering dead CTAs, missing backend/API targets, missing state/projection, missing audit/provenance, authority bypass, degraded-mode visibility, placeholder leakage, route/event drift, omitted material routes, first E2E `/alerts` acknowledgement proof, deployment evidence, gates, migration drift, rollback, health/smoke, dependency readiness, and evidence package completeness.
+
+### Blockers
+
+No document-quality blocker remains for CS2 disposition.
+
+### Risks / conditions
+
+- Tests are specified, not implemented.
+- Stage 8 must import all QA-FD and QA-DEPLOY rows.
+- Stage 12 must produce runnable evidence, not only documentation.
+- Stub, skipped, todo, or trivially passing tests must remain blocking defects.
+
+### Recommended disposition
+
+**Recommendation**: CS2 approve Stage 6 QA-to-Red with QA-FD and QA-DEPLOY conditions attached.
+
+---
+
+## 6. Stage 7 - PBFAG
+
+### Readiness
+
+The Stage 7 PBFAG pack is structurally ready for CS2 disposition once PR #1194 is clean. It verifies artifact presence, approval posture, tracker/index alignment, Stage 8 gate conditions, and the requirement that Stage 8 remains blocked until Stages 5, 5a, 6, and 7 are dispositioned.
+
+The Stage 7 retrofit imports the Stage 5 architecture map, Stage 5a deployment execution validation matrix, and Stage 6 QA-FD / QA-DEPLOY families as hard PBFAG checks.
+
+### Blockers
+
+No document-quality blocker remains once PR #1194 review threads and gates are clean.
+
+### Risks / conditions
+
+- Stage 7 approval must not be treated as Stage 8 approval.
+- Stage 8 must import PBFAG-FD, PBFAG-DEPLOY, PBFAG-QA, tracker/index, and Stage 8 block rows.
+- The first E2E `/alerts` acknowledgement path must be retained.
+- Placeholder or partial evidence must not count as functional completion.
+
+### Recommended disposition
+
+**Recommendation**: CS2 approve Stage 7 PBFAG with retrofit conditions attached, after PR #1194 is clean and merged.
+
+---
+
+## 7. Consolidated Stage 8 Conditions
+
+If CS2 later opens Stage 8, the Stage 8 issue and implementation plan must import at minimum:
+
+1. Stage 5 route/action/state/audit/degraded-mode map.
+2. Stage 5a deployment validation matrix, including CI and preview boundaries.
+3. Stage 6 QA-FD and QA-DEPLOY rows.
+4. Stage 7 PBFAG-FD, PBFAG-DEPLOY, PBFAG-QA, PBFAG-TRACK, and PBFAG-STAGE8 rows.
+5. First E2E `/alerts` acknowledgement path.
+6. Placeholder/stub rejection rule.
+7. Production approval gates.
+8. Secret separation across PR, preview, staging, and production.
+9. Supabase migration command freeze.
+10. Rollback evidence planning.
+11. Runtime health/smoke validation.
+12. External dependency readiness and visible degraded-mode behavior.
+13. Complete implementation evidence package.
+14. Tracker and artifact-index updates.
+
+---
+
+## 8. Consolidated CS2 Decision Template
+
+```text
+CS2 Disposition - AMC Stages 5, 5a, 6, and 7
+
+Stage 5 Architecture: APPROVED / APPROVED WITH AMENDMENTS / NOT APPROVED
+Notes:
+
+Stage 5a Deployment Execution Strategy: APPROVED / APPROVED WITH AMENDMENTS / NOT APPROVED
+Notes:
+
+Stage 6 QA-to-Red: APPROVED / APPROVED WITH AMENDMENTS / NOT APPROVED
+Notes:
+
+Stage 7 PBFAG: APPROVED / APPROVED WITH AMENDMENTS / NOT APPROVED
+Notes:
+
+Stage 8 Authorization: NOT AUTHORIZED / AUTHORIZED BY SEPARATE ISSUE ONLY
+Notes:
+
+CS2 Name:
+Date:
+```
+
+---
+
+## 9. Closure Statement
+
+Foreman recommends conditional CS2 approval of Stages 5, 5a, 6, and 7 with the above conditions attached.
+
+This disposition pack does not begin Stage 8, does not create implementation work, does not appoint builders, and does not start build.

--- a/modules/amc/06-pbfag/functional-delivery-pbfag-addendum.md
+++ b/modules/amc/06-pbfag/functional-delivery-pbfag-addendum.md
@@ -1,0 +1,134 @@
+# AMC Stage 7 Addendum - Functional Delivery / Deployment Execution / QA PBFAG
+
+**Stage**: 7 - PBFAG addendum  
+**Module**: App Management Centre (AMC)  
+**Version**: 1.0  
+**Status**: Produced for CS2 review  
+**Wave**: amc-stage7-pbfag-retrofit-20260630  
+**Issue**: app_management_centre#1193  
+**Authority basis**: PR #1186, PR #1188, PR #1190, PR #1192, Stage 5 architecture map, Stage 5a deployment execution validation matrix, Stage 6 QA-FD and QA-DEPLOY RED families  
+**Non-scope**: This addendum does not start Stage 8, builder checklist, IAA pre-brief, builder appointment, implementation, or build-readiness certification.
+
+---
+
+## 1. Purpose
+
+This addendum imports the merged Stage 5, Stage 5a, and Stage 6 retrofit obligations into Stage 7 PBFAG.
+
+The existing Stage 7 artifacts remain the primary PBFAG pack:
+
+- `pre-build-final-assurance-gate.md`;
+- `pbfag-evidence-matrix.md`;
+- `pbfag-findings-and-verdict.md`;
+- `pbfag-checklist.md`.
+
+This addendum adds the functional-delivery, deployment-execution, and QA-to-Red gate layer created after the original Stage 7 pack was produced.
+
+---
+
+## 2. PBFAG Retrofit Rule
+
+Stage 7 must verify that the pre-build chain prevents a non-functional build.
+
+PBFAG must hard-gate whether the package defines testable proof for:
+
+1. visible user action and CTA closure;
+2. API or external service target coverage;
+3. state owner, table, or projection coverage;
+4. audit and provenance evidence;
+5. server-side authority-gate proof;
+6. user-visible degraded-mode behavior;
+7. placeholder and stub rejection;
+8. route and event naming authority;
+9. omitted material-route prevention;
+10. deployment execution validation;
+11. environment and secret-boundary proof;
+12. migration command and rollback proof;
+13. runtime health and smoke proof;
+14. external dependency readiness or degraded-mode proof;
+15. first E2E `/alerts` acknowledgement proof.
+
+If any item is missing, ambiguous, or only implied, Stage 7 must fail or condition Stage 8.
+
+---
+
+## 3. Stage 5 Import
+
+Stage 7 must import the Stage 5 architecture map as a hard PBFAG input.
+
+| Stage 5 obligation | PBFAG treatment |
+|---|---|
+| Material route inventory | Verify no material route is omitted from QA/PBFAG evidence |
+| CTA/action mapping | Reject dead CTA or action-without-target completion claims |
+| State/projection mapping | Require state ownership evidence for consequential actions |
+| Audit/provenance mapping | Require audit/provenance proof for consequential actions |
+| Authority-gate mapping | Require server-side authority proof before side effects |
+| Degraded-mode mapping | Require visible degraded/stale/unavailable states |
+| Placeholder control | Reject placeholder/stub evidence as completion proof |
+| Route/event authority | Reject canonical-name drift without CS2 disposition |
+
+---
+
+## 4. Stage 5a Import
+
+Stage 7 must import the Stage 5a deployment execution validation matrix as a hard PBFAG input.
+
+| Stage 5a obligation | PBFAG treatment |
+|---|---|
+| Workflow ownership | Verify named workflow ownership is testable or CS2-dispositioned |
+| Protected production gate | Fail if production deploy/migration lacks protected approval boundary |
+| Secret isolation | Fail if PR/staging can access production secrets |
+| Migration command freeze | Fail if migration command drift is allowed |
+| Rollback evidence | Condition Stage 8 if rollback/revert/restore evidence is undefined |
+| Environment template | Require runtime variable contract coverage |
+| Runtime health/smoke | Require health/smoke validation evidence later |
+| Dependency readiness | Require readiness or degraded evidence for AIMC, AIMCC, KUC, knowledge, Foreman, specialists, push, Supabase, and Vercel |
+| Evidence package | Require deployed URL/API/state/audit/env/dependency/visual-log proof for implementation closure |
+| Placeholder deployment proof | Reject placeholder screenshots/logs as completion proof |
+
+---
+
+## 5. Stage 6 Import
+
+Stage 7 must import the Stage 6 QA-FD and QA-DEPLOY RED test families as blocker-grade PBFAG checks.
+
+PBFAG must verify that Stage 6 covers, or explicitly dispositions, every `QA-FD-*` and `QA-DEPLOY-*` row before Stage 8 can be considered.
+
+The Stage 7 verdict must remain conditional or fail if:
+
+- any QA-FD row is missing from Stage 7 evidence;
+- any QA-DEPLOY row is missing from Stage 7 evidence;
+- any row can pass against a stub or placeholder;
+- any row lacks exact RED/fail and GREEN/pass expectations;
+- any row lacks a downstream evidence owner for implementation planning.
+
+---
+
+## 6. First E2E Path Binding
+
+The first E2E evidence path is `/alerts` acknowledgement:
+
+`/alerts` UI -> acknowledge CTA -> alert acknowledge API -> authority check -> alerts state update -> audit_events insert -> realtime update -> visible acknowledged state -> audit verification.
+
+This path may not be treated as complete if only one layer passes. The evidence must prove the full user-visible and audit-visible journey.
+
+---
+
+## 7. Stage 8 Block Rule
+
+Stage 8 remains blocked until CS2 explicitly dispositions:
+
+1. Stage 5 original architecture plus Stage 5 retrofit package;
+2. Stage 5a original DES pack plus Stage 5a retrofit package;
+3. Stage 6 original QA-to-Red pack plus Stage 6 retrofit package;
+4. Stage 7 original PBFAG pack plus this retrofit package.
+
+This addendum does not approve any stage by itself and does not authorize Stage 8.
+
+---
+
+## 8. Disposition Statement
+
+Stage 7 may be treated as functionally aligned only if this addendum, the PBFAG retrofit evidence matrix, and the Stage 7 change-propagation audit are reviewed and accepted or explicitly amended by CS2.
+
+Until then, Stage 7 remains produced for review and Stage 8 remains blocked.

--- a/modules/amc/06-pbfag/pbfag-retrofit-evidence-matrix.md
+++ b/modules/amc/06-pbfag/pbfag-retrofit-evidence-matrix.md
@@ -41,6 +41,8 @@ It does not implement tests. It defines the gate evidence that must exist before
 | PBFAG-DEPLOY-007 | Stage 5a matrix | Runtime health/smoke proof is required | Health/smoke proof is a closure requirement | Feature closure lacks smoke proof | BLOCK |
 | PBFAG-DEPLOY-008 | Stage 5a matrix | Dependency readiness/degraded evidence is required | AIMC/AIMCC/KUC/knowledge/Foreman/specialist/push/Supabase/Vercel readiness or degraded evidence required | Dependency failure hidden | BLOCK |
 | PBFAG-DEPLOY-009 | Stage 5a matrix | Deployment evidence package is defined | URL/API/state/audit/env/dependency/visual-log proof required | Feature marked complete without bundle | BLOCK |
+| PBFAG-DEPLOY-010 | Stage 5a matrix | CI boundary is preserved | PR CI may lint/test/schema-check only and must not mutate production | PR CI can mutate production or use live credentials | BLOCK |
+| PBFAG-DEPLOY-011 | Stage 5a matrix | Preview boundary is preserved | Preview deploy uses staging/preview resources only | Preview uses production data or production credentials | BLOCK |
 | PBFAG-QA-001 | Stage 6 QA-FD family | QA-FD family imported | QA-FD-001 through QA-FD-015 are visible in PBFAG evidence | Any QA-FD row omitted | BLOCK |
 | PBFAG-QA-002 | Stage 6 QA-DEPLOY family | QA-DEPLOY family imported | QA-DEPLOY-001 through QA-DEPLOY-010 are visible in PBFAG evidence | Any QA-DEPLOY row omitted | BLOCK |
 | PBFAG-QA-003 | Stage 6 matrix | Fail/pass criteria are exact | Each QA-FD/QA-DEPLOY row has RED and GREEN expectations | Vague pass criteria | BLOCK |

--- a/modules/amc/06-pbfag/pbfag-retrofit-evidence-matrix.md
+++ b/modules/amc/06-pbfag/pbfag-retrofit-evidence-matrix.md
@@ -1,0 +1,70 @@
+# AMC Stage 7 PBFAG Retrofit Evidence Matrix
+
+**Stage**: 7 - PBFAG retrofit evidence matrix  
+**Module**: App Management Centre (AMC)  
+**Version**: 1.0  
+**Status**: Produced for CS2 review  
+**Wave**: amc-stage7-pbfag-retrofit-20260630  
+**Issue**: app_management_centre#1193  
+**Authority basis**: PR #1186, PR #1188, PR #1190, PR #1192  
+**Non-scope**: This matrix does not start Stage 8, builder checklist, IAA pre-brief, builder appointment, implementation, or build-readiness certification.
+
+---
+
+## 1. Purpose
+
+This matrix maps the Stage 5, Stage 5a, and Stage 6 retrofit obligations into Stage 7 PBFAG checks.
+
+It does not implement tests. It defines the gate evidence that must exist before Stage 8 can be considered by CS2.
+
+---
+
+## 2. Matrix
+
+| Check ID | Source | PBFAG requirement | Pass condition | Fail / condition trigger | Stage 8 effect |
+|---|---|---|---|---|---|
+| PBFAG-FD-001 | Stage 5 architecture map | Material routes are covered | Every material route is listed in QA/PBFAG evidence or explicitly CS2-dispositioned | Material route omitted | BLOCK |
+| PBFAG-FD-002 | Stage 5 architecture map | CTAs/actions have targets | Every material CTA maps to API/service/read-only declaration | Dead CTA or action target missing | BLOCK |
+| PBFAG-FD-003 | Stage 5 architecture map | State/projection ownership is defined | Consequential actions have state owner/table/projection evidence | No state owner for action | BLOCK |
+| PBFAG-FD-004 | FR-1900/TR-1900/Stage 5 map | Audit/provenance coverage exists | Consequential actions define audit/provenance proof | Success path lacks audit/provenance | BLOCK |
+| PBFAG-FD-005 | ARC authority / Stage 5 map | Authority checks are server-side and pre-effect | Side effects require authority gate evidence | Side effect can occur before authority proof | BLOCK |
+| PBFAG-FD-006 | Stage 5 map | Degraded-mode behavior is visible | Dependency failure maps to visible unavailable/stale/degraded state | Silent no-op, blank state, or false success | BLOCK |
+| PBFAG-FD-007 | Stage 5 addendum | Placeholder/stub evidence is rejected | Placeholder evidence is excluded unless CS2-dispositioned | Placeholder counted as complete | BLOCK |
+| PBFAG-FD-008 | Stage 2/TRS/Stage 5 map | Route/event naming authority is preserved | Canonical names are used or drift is dispositioned | Non-canonical route/event used without disposition | BLOCK |
+| PBFAG-FD-009 | Stage 5 map | First E2E path is bound | `/alerts` acknowledgement path has full evidence requirement | Only UI/API/state/audit partial proof exists | BLOCK |
+| PBFAG-DEPLOY-001 | Stage 5a matrix | Workflow ownership is testable | Named workflows or CS2-approved equivalents are identified | Workflow ownership unclear | BLOCK |
+| PBFAG-DEPLOY-002 | Stage 5a matrix | Production approval gate is protected | Production deploy/migration requires protected environment approval | Ungated production action allowed | BLOCK |
+| PBFAG-DEPLOY-003 | Stage 5a matrix | Secrets are isolated | Production secrets are scoped to production-only contexts | PR/staging can access production secrets | BLOCK |
+| PBFAG-DEPLOY-004 | Stage 5a matrix | Migration command is frozen | Supabase migration command is fixed or amended by CS2 | Migration command drift allowed | BLOCK |
+| PBFAG-DEPLOY-005 | Stage 5a matrix | Rollback evidence is required | Rollback/revert/restore evidence requirement exists | Rollback path undefined | CONDITION/BLOCK |
+| PBFAG-DEPLOY-006 | Stage 5a matrix | Runtime variables are contracted | `.env.example` or equivalent runtime contract coverage exists | Required runtime var undocumented | BLOCK |
+| PBFAG-DEPLOY-007 | Stage 5a matrix | Runtime health/smoke proof is required | Health/smoke proof is a closure requirement | Feature closure lacks smoke proof | BLOCK |
+| PBFAG-DEPLOY-008 | Stage 5a matrix | Dependency readiness/degraded evidence is required | AIMC/AIMCC/KUC/knowledge/Foreman/specialist/push/Supabase/Vercel readiness or degraded evidence required | Dependency failure hidden | BLOCK |
+| PBFAG-DEPLOY-009 | Stage 5a matrix | Deployment evidence package is defined | URL/API/state/audit/env/dependency/visual-log proof required | Feature marked complete without bundle | BLOCK |
+| PBFAG-QA-001 | Stage 6 QA-FD family | QA-FD family imported | QA-FD-001 through QA-FD-015 are visible in PBFAG evidence | Any QA-FD row omitted | BLOCK |
+| PBFAG-QA-002 | Stage 6 QA-DEPLOY family | QA-DEPLOY family imported | QA-DEPLOY-001 through QA-DEPLOY-010 are visible in PBFAG evidence | Any QA-DEPLOY row omitted | BLOCK |
+| PBFAG-QA-003 | Stage 6 matrix | Fail/pass criteria are exact | Each QA-FD/QA-DEPLOY row has RED and GREEN expectations | Vague pass criteria | BLOCK |
+| PBFAG-QA-004 | Stage 6 audit | Stage 7 import requirement preserved | Stage 7 explicitly imports QA-FD/QA-DEPLOY blockers | Stage 7 does not import Stage 6 retrofit | BLOCK |
+| PBFAG-TRACK-001 | Tracker / index | Tracker and index agree | Tracker and artifact index list Stage 7 retrofit artifacts | Mismatch or stale current action | BLOCK |
+| PBFAG-STAGE8-001 | Stage 7 verdict | Stage 8 block is preserved | Stage 8 remains blocked until Stage 5, 5a, 6, and 7 are dispositioned | Stage 8 starts early | BLOCK |
+
+---
+
+## 3. Required Stage 7 Evidence Package
+
+Stage 7 review must include:
+
+1. existing PBFAG pack;
+2. Stage 5 architecture map and Stage 5 change-propagation audit;
+3. Stage 5a deployment execution validation matrix and audit;
+4. Stage 6 QA-FD/QA-DEPLOY expansion matrix and audit;
+5. tracker and artifact-index alignment evidence;
+6. explicit statement that Stage 8 remains blocked.
+
+---
+
+## 4. Verdict
+
+This matrix makes the Stage 7 gate stricter and better aligned to fully functional build readiness.
+
+It is not an implementation plan and does not authorize Stage 8.

--- a/modules/amc/06-pbfag/stage7-functional-delivery-change-propagation-audit.md
+++ b/modules/amc/06-pbfag/stage7-functional-delivery-change-propagation-audit.md
@@ -1,0 +1,102 @@
+# AMC Stage 7 Functional Delivery Change-Propagation Audit
+
+**Artifact Type**: Change-Propagation Audit  
+**Stage**: 7 - PBFAG  
+**Module**: App Management Centre (AMC)  
+**Version**: 1.0  
+**Status**: Produced for CS2 review  
+**Wave**: amc-stage7-pbfag-retrofit-20260630  
+**Issue**: app_management_centre#1193  
+**Authority basis**: PR #1186, PR #1188, PR #1190, PR #1192, existing Stage 7 PBFAG artifacts  
+**Non-scope**: This audit does not start Stage 8, builder checklist, IAA pre-brief, builder appointment, implementation, or build-readiness certification.
+
+---
+
+## 1. Purpose
+
+This audit checks whether the existing Stage 7 PBFAG pack absorbs the merged Stage 5, Stage 5a, and Stage 6 retrofit chain.
+
+---
+
+## 2. Inputs Reviewed
+
+| Input | Review relevance |
+|---|---|
+| `pre-build-final-assurance-gate.md` | Existing Stage 7 master gate artifact |
+| `pbfag-evidence-matrix.md` | Existing Stage 7 evidence matrix |
+| `pbfag-findings-and-verdict.md` | Existing Stage 7 findings and gate condition |
+| `pbfag-checklist.md` | Existing Stage 7 checklist artifact |
+| `functional-delivery-architecture-map.md` | Stage 5 route/action/state/audit/degraded-mode map |
+| `deployment-execution-validation-matrix.md` | Stage 5a deployment-execution validation domains |
+| `functional-delivery-red-test-expansion-matrix.md` | Stage 6 QA-FD and QA-DEPLOY RED families |
+| `BUILD_PROGRESS_TRACKER.md` | Live progress and blocker posture |
+| `AMC_PRE_BUILD_ARTIFACT_INDEX.md` | Artifact-index alignment |
+
+---
+
+## 3. Findings
+
+| Area | Existing Stage 7 posture | Retrofit finding | Result |
+|---|---|---|---|
+| PBFAG structure | Existing pack has master gate, evidence matrix, findings, and checklist | Strong baseline | CLEAN |
+| Stage 8 gate | Existing pack blocks Stage 8 until Stage 5, 5a, 6, and 7 are approved | Correct boundary | CLEAN |
+| Stage 5 import | Existing pack predates Stage 5 route/action/state/audit map | Needed explicit hard-gate import | RESOLVED BY RETROFIT |
+| Stage 5a import | Existing pack predates Stage 5a deployment validation matrix | Needed explicit deployment gate import | RESOLVED BY RETROFIT |
+| Stage 6 import | Existing pack predates QA-FD and QA-DEPLOY families | Needed explicit QA blocker import | RESOLVED BY RETROFIT |
+| First E2E evidence | Existing pack did not bind `/alerts` acknowledgement as first full journey proof | Needed explicit evidence path | RESOLVED BY RETROFIT |
+| Placeholder rejection | Existing pack needed stricter wording for placeholder/stub proof | Added explicit PBFAG blocker rows | RESOLVED BY RETROFIT |
+| Dependency readiness | Existing pack predates AIMC/AIMCC/KUC/knowledge/Foreman/specialist/push readiness matrix | Added dependency proof import | RESOLVED BY RETROFIT |
+| Tracker/index alignment | Tracker was stale after PR #1192 merge | Tracker updated first in this wave | CLEAN |
+| Stage 8 readiness | Stage 7 retrofit alone cannot authorize Stage 8 | Must remain blocked | CLEAN |
+
+---
+
+## 4. Gap Register
+
+| Gap ID | Gap | Severity | Status after this wave |
+|---|---|---|---|
+| AMC-S7-FD-GAP-001 | Existing Stage 7 predates Stage 5/5a/6 retrofit chain | High | Addressed by addendum |
+| AMC-S7-FD-GAP-002 | Functional-delivery hard gates not explicit enough | High | Addressed by PBFAG-FD rows |
+| AMC-S7-FD-GAP-003 | Deployment-execution hard gates not explicit enough | High | Addressed by PBFAG-DEPLOY rows |
+| AMC-S7-FD-GAP-004 | QA-FD and QA-DEPLOY families not visible in Stage 7 | High | Addressed by PBFAG-QA rows |
+| AMC-S7-FD-GAP-005 | First E2E `/alerts` acknowledgement evidence path not in Stage 7 | High | Addressed by addendum |
+| AMC-S7-FD-GAP-006 | Tracker still pointed to Stage 6 after PR #1192 merge | Medium | Addressed by tracker update |
+
+---
+
+## 5. Downstream Propagation Requirements
+
+If CS2 later authorizes Stage 8, Stage 8 must import:
+
+- PBFAG-FD blocker rows;
+- PBFAG-DEPLOY blocker rows;
+- PBFAG-QA blocker rows;
+- first E2E `/alerts` acknowledgement evidence path;
+- rejection of placeholder/stub evidence;
+- deployment evidence package requirements;
+- tracker/index agreement requirements.
+
+Stage 8 remains blocked until CS2 dispositions Stage 5, Stage 5a, Stage 6, and Stage 7.
+
+---
+
+## 6. Verdict
+
+The existing Stage 7 PBFAG pack is not rejected. It is structurally strong and already blocks Stage 8 until Stage 5, Stage 5a, Stage 6, and Stage 7 are dispositioned.
+
+This retrofit adds the missing hard-gate layer for functional-delivery closure, deployment-execution proof, QA-FD/QA-DEPLOY coverage, first E2E evidence, and placeholder/stub rejection.
+
+**Verdict**: CONDITIONAL PASS FOR STAGE 7 RETROFIT PRODUCTION; NOT BUILD-READY; NOT STAGE-8-READY.
+
+**Required CS2 disposition**:
+
+1. Accept or amend `functional-delivery-pbfag-addendum.md`.
+2. Accept or amend `pbfag-retrofit-evidence-matrix.md`.
+3. Accept or amend this change-propagation audit.
+4. Decide whether the existing Stage 7 PBFAG pack may be approved with these retrofit artifacts attached.
+
+---
+
+## 7. Foreman Closure Statement
+
+This audit completes the Stage 7 retrofit package for review. It does not approve Stage 7, does not start Stage 8, does not appoint builders, and does not authorize implementation.

--- a/modules/amc/AMC_PRE_BUILD_ARTIFACT_INDEX.md
+++ b/modules/amc/AMC_PRE_BUILD_ARTIFACT_INDEX.md
@@ -2,7 +2,7 @@
 
 **Module**: App Management Centre (AMC)  
 **Lifecycle Model**: 12-Stage Pre-Build Sequence + Stage 5a (PRE_BUILD_STAGE_MODEL_CANON.md v1.0.0; AMC-GOV-OVERSIGHT-001)  
-**Last Updated**: 2026-06-30 (Stage 7 PBFAG functional-delivery / deployment-execution / QA retrofit artifacts produced for CS2 review - wave amc-stage7-pbfag-retrofit-20260630; issue #1193. Prior: Stage 6 QA-to-Red functional-delivery retrofit merged as approval-pending reference input - issue #1191; PR #1192. Prior: Stage 5a retrofit merged as approval-pending reference input - issue #1189; PR #1190. Prior: Stage 5 architecture retrofit merged as approval-pending reference input - issue #1187; PR #1188. Prior: Stage 1-4 retrofit merged - issue #1185; PR #1186.)  
+**Last Updated**: 2026-06-30 (Stage 7 PBFAG functional-delivery / deployment-execution / QA retrofit artifacts produced for CS2 review - wave amc-stage7-pbfag-retrofit-20260630; issue #1193; PR #1194. Prior: Stage 6 QA-to-Red functional-delivery retrofit merged as approval-pending reference input - issue #1191; PR #1192. Prior: Stage 5a retrofit merged as approval-pending reference input - issue #1189; PR #1190. Prior: Stage 5 architecture retrofit merged as approval-pending reference input - issue #1187; PR #1188. Prior: Stage 1-4 retrofit merged - issue #1185; PR #1186.)  
 **Authority**: Maturion Foreman / CS2
 
 ---
@@ -17,12 +17,12 @@ This index catalogs all pre-build artifacts for the AMC module, mapped to their 
 
 | Artifact | Location | Status | Notes |
 |----------|----------|--------|-------|
-| App Description | `modules/amc/00-app-description/app-description.md` | Approved Canonical | v1.0, CS2-approved 2026-04-22. Sole authoritative Stage 1 source. Approval ref: #1117. |
-| App Description Approval | `modules/amc/00-app-description/app-description-approval.md` | Complete | Formal Stage 1 approval record. |
-| Functional Delivery Definition | `modules/amc/00-app-description/functional-delivery-definition.md` | Retrofit Reference Input | Produced/merged in PR #1186. Adds fully functional delivery definition. CS2 disposition required as part of retrofit chain. |
-| AMC Role Authority & Operating Model | `modules/amc/00-app-description/amc-role-authority-and-operating-model.md` | Placeholder | Follow-on work required. Does not block Stage 2. |
-| FM App Description (superseded) | `docs/governance/FM_APP_DESCRIPTION.md` | Superseded | Retained as historical/provenance reference only. |
-| App Description (root pointer) | `APP_DESCRIPTION.md` | Reference Only | Follow-on update to point to canonical location pending. |
+| App Description | `modules/amc/00-app-description/app-description.md` | ✅ Approved Canonical | v1.0, CS2-approved 2026-04-22. Sole authoritative Stage 1 source. Approval ref: #1117. |
+| App Description Approval | `modules/amc/00-app-description/app-description-approval.md` | ✅ Complete | Formal Stage 1 approval record. |
+| Functional Delivery Definition | `modules/amc/00-app-description/functional-delivery-definition.md` | 🟡 Retrofit Reference Input | Produced/merged in PR #1186. Adds fully functional delivery definition. CS2 disposition required as part of retrofit chain. |
+| AMC Role Authority & Operating Model | `modules/amc/00-app-description/amc-role-authority-and-operating-model.md` | ⬜ Placeholder | Follow-on work required. Does not block Stage 2. |
+| FM App Description (superseded) | `docs/governance/FM_APP_DESCRIPTION.md` | 📦 Superseded | Retained as historical/provenance reference only. |
+| App Description (root pointer) | `APP_DESCRIPTION.md` | 📌 Reference Only | Follow-on update to point to canonical location pending. |
 
 ---
 
@@ -30,9 +30,9 @@ This index catalogs all pre-build artifacts for the AMC module, mapped to their 
 
 | Artifact | Location | Status | Notes |
 |----------|----------|--------|-------|
-| UX Workflow & Wiring Spec | `modules/amc/01-ux-workflow-wiring-spec/ux-workflow-wiring-spec.md` | Approved Canonical | v1.1, CS2-approved 2026-04-22. |
-| Wiring Artifact Index | `modules/amc/01-ux-workflow-wiring-spec/wiring-artifact-index.md` | Approved Canonical | v1.0, CS2-approved 2026-04-22. |
-| CTA/API/Data/Audit Contract Matrix | `modules/amc/01-ux-workflow-wiring-spec/cta-api-data-audit-contract-matrix.md` | Retrofit Reference Input | Produced/merged in PR #1186. Canonical endpoint/event authority remains with Stage 4 TRS. |
+| UX Workflow & Wiring Spec | `modules/amc/01-ux-workflow-wiring-spec/ux-workflow-wiring-spec.md` | ✅ Approved Canonical | v1.1, CS2-approved 2026-04-22. |
+| Wiring Artifact Index | `modules/amc/01-ux-workflow-wiring-spec/wiring-artifact-index.md` | ✅ Approved Canonical | v1.0, CS2-approved 2026-04-22. |
+| CTA/API/Data/Audit Contract Matrix | `modules/amc/01-ux-workflow-wiring-spec/cta-api-data-audit-contract-matrix.md` | 🟡 Retrofit Reference Input | Produced/merged in PR #1186. Canonical endpoint/event authority remains with Stage 4 TRS. CS2 disposition required as part of retrofit chain. |
 
 ---
 
@@ -40,9 +40,9 @@ This index catalogs all pre-build artifacts for the AMC module, mapped to their 
 
 | Artifact | Location | Status | Notes |
 |----------|----------|--------|-------|
-| Functional Requirements Specification | `modules/amc/02-frs/functional-requirements-specification.md` | Approved Canonical | v1.1, CS2-approved for Stage 4 progression 2026-04-23. |
-| App Description to FRS Traceability | `modules/amc/02-frs/app-description-to-frs-traceability.md` | Approved Canonical | v1.0, CS2-approved for Stage 4 progression 2026-04-23. |
-| Functional Delivery Requirements Addendum | `modules/amc/02-frs/functional-delivery-requirements-addendum.md` | Retrofit Reference Input | FR-1900 produced/merged in PR #1186. |
+| Functional Requirements Specification | `modules/amc/02-frs/functional-requirements-specification.md` | ✅ Approved Canonical | v1.1, CS2-approved for Stage 4 progression 2026-04-23. |
+| App Description to FRS Traceability | `modules/amc/02-frs/app-description-to-frs-traceability.md` | ✅ Approved Canonical | v1.0, CS2-approved for Stage 4 progression 2026-04-23. |
+| Functional Delivery Requirements Addendum | `modules/amc/02-frs/functional-delivery-requirements-addendum.md` | 🟡 Retrofit Reference Input | FR-1900 produced/merged in PR #1186. CS2 disposition required as part of retrofit chain. |
 
 ---
 
@@ -50,9 +50,9 @@ This index catalogs all pre-build artifacts for the AMC module, mapped to their 
 
 | Artifact | Location | Status | Notes |
 |----------|----------|--------|-------|
-| Technical Requirements Specification | `modules/amc/03-trs/technical-requirements-specification.md` | Treated as Approved | v1.1, hardened approval-ready 2026-04-23. Formal CS2 approval pending. |
-| FRS to TRS Traceability | `modules/amc/03-trs/frs-to-trs-traceability.md` | Treated as Approved | v1.1, hardened 2026-04-23. |
-| Functional Delivery Technical Requirements Addendum | `modules/amc/03-trs/functional-delivery-technical-requirements-addendum.md` | Retrofit Reference Input | TR-1900, including TR-1910, produced/merged in PR #1186. |
+| Technical Requirements Specification | `modules/amc/03-trs/technical-requirements-specification.md` | 🟠 Treated as Approved | v1.1, hardened approval-ready 2026-04-23. Formal CS2 approval pending. |
+| FRS to TRS Traceability | `modules/amc/03-trs/frs-to-trs-traceability.md` | 🟠 Treated as Approved | v1.1, hardened 2026-04-23. |
+| Functional Delivery Technical Requirements Addendum | `modules/amc/03-trs/functional-delivery-technical-requirements-addendum.md` | 🟡 Retrofit Reference Input | TR-1900, including TR-1910, produced/merged in PR #1186. CS2 disposition required as part of retrofit chain. |
 
 ---
 
@@ -60,16 +60,16 @@ This index catalogs all pre-build artifacts for the AMC module, mapped to their 
 
 | Artifact | Location | Status | Notes |
 |----------|----------|--------|-------|
-| Architecture Specification | `modules/amc/04-architecture/architecture-specification.md` | Approval Pending | v1.0, produced 2026-04-26. CS2 approval required. |
-| TRS-to-Architecture Traceability | `modules/amc/04-architecture/trs-to-architecture-traceability.md` | Approval Pending | v1.0, produced 2026-04-26. |
-| Functional Delivery Architecture Addendum | `modules/amc/04-architecture/functional-delivery-architecture-addendum.md` | Retrofit Reference Input | Produced/merged in PR #1188. |
-| Functional Delivery Architecture Map | `modules/amc/04-architecture/functional-delivery-architecture-map.md` | Retrofit Reference Input | Produced/merged in PR #1188. Route/action/state/audit/degraded-mode map for Stage 6/7 derivation. |
-| Stage 5 Functional Delivery Change-Propagation Audit | `modules/amc/04-architecture/stage5-functional-delivery-change-propagation-audit.md` | Retrofit Reference Input | Produced/merged in PR #1188. Conditional pass for retrofit production; not build-ready and not Stage-8-ready. |
-| Stage 5 Review Notes | `modules/amc/04-architecture/stage5-review-notes.md` | Retrofit Reference Input | Produced/merged in PR #1188. |
-| Stage 5 Coverage Note | `modules/amc/04-architecture/extra-review-note.md` | Retrofit Reference Input | Produced/merged in PR #1188. |
-| Architecture (superseded placeholder) | `modules/amc/04-architecture/architecture.md` | Superseded | `architecture-specification.md` is the canonical Stage 5 artifact. |
-| Architecture Decision Records | `modules/amc/04-architecture/architecture-decision-records.md` | Placeholder | Not started. |
-| Architecture Completeness Checklist | `modules/amc/04-architecture/architecture-completeness-checklist.md` | Placeholder | Not started / remains a placeholder unless separately populated. |
+| Architecture Specification | `modules/amc/04-architecture/architecture-specification.md` | 🟡 Approval Pending | v1.0, produced 2026-04-26. CS2 approval required. |
+| TRS-to-Architecture Traceability | `modules/amc/04-architecture/trs-to-architecture-traceability.md` | 🟡 Approval Pending | v1.0, produced 2026-04-26. |
+| Functional Delivery Architecture Addendum | `modules/amc/04-architecture/functional-delivery-architecture-addendum.md` | 🟡 Retrofit Reference Input | Produced/merged in PR #1188. CS2 disposition required. |
+| Functional Delivery Architecture Map | `modules/amc/04-architecture/functional-delivery-architecture-map.md` | 🟡 Retrofit Reference Input | Produced/merged in PR #1188. Route/action/state/audit/degraded-mode map for Stage 6/7 derivation. CS2 disposition required. |
+| Stage 5 Functional Delivery Change-Propagation Audit | `modules/amc/04-architecture/stage5-functional-delivery-change-propagation-audit.md` | 🟡 Retrofit Reference Input | Produced/merged in PR #1188. Conditional pass for retrofit production; not build-ready and not Stage-8-ready. |
+| Stage 5 Review Notes | `modules/amc/04-architecture/stage5-review-notes.md` | 🟡 Retrofit Reference Input | Produced/merged in PR #1188. |
+| Stage 5 Coverage Note | `modules/amc/04-architecture/extra-review-note.md` | 🟡 Retrofit Reference Input | Produced/merged in PR #1188. |
+| Architecture (superseded placeholder) | `modules/amc/04-architecture/architecture.md` | ⛔ Superseded | `architecture-specification.md` is the canonical Stage 5 artifact. |
+| Architecture Decision Records | `modules/amc/04-architecture/architecture-decision-records.md` | ⬜ Placeholder | Not started. |
+| Architecture Completeness Checklist | `modules/amc/04-architecture/architecture-completeness-checklist.md` | ⬜ Placeholder | Not started / remains a placeholder unless separately populated. |
 
 ---
 
@@ -77,13 +77,13 @@ This index catalogs all pre-build artifacts for the AMC module, mapped to their 
 
 | Artifact | Location | Status | Notes |
 |----------|----------|--------|-------|
-| Deployment Execution Strategy | `modules/amc/05a-deployment-execution-strategy/deployment-execution-strategy.md` | Approval Pending | v1.0, produced 2026-04-27. CS2 approval required. |
-| Deployment Surface Ownership Table | `modules/amc/05a-deployment-execution-strategy/deployment-surface-ownership-table.md` | Approval Pending | v1.0, produced 2026-04-27. |
-| Runner and Environment Constraints | `modules/amc/05a-deployment-execution-strategy/runner-and-environment-constraints.md` | Approval Pending | v1.0, produced 2026-04-27. |
-| Functional Delivery Deployment Execution Addendum | `modules/amc/05a-deployment-execution-strategy/functional-delivery-deployment-execution-addendum.md` | Retrofit Reference Input | Produced/merged in PR #1190. Imports TR-1910, Stage 5 architecture map, deployment evidence, runtime health/smoke validation, dependency readiness, and no-operational-speculation controls. |
-| Deployment Execution Validation Matrix | `modules/amc/05a-deployment-execution-strategy/deployment-execution-validation-matrix.md` | Retrofit Reference Input | Produced/merged in PR #1190. Adds workflow, environment, migration, protected approval, health, rollback, dependency, audit, and evidence validation obligations for Stage 6/7 derivation. |
-| Stage 5a Functional Delivery Change-Propagation Audit | `modules/amc/05a-deployment-execution-strategy/stage5a-functional-delivery-change-propagation-audit.md` | Retrofit Reference Input | Produced/merged in PR #1190. Conditional pass for Stage 5a retrofit production; not build-ready and not Stage-8-ready. |
-| Governance Oversight Record | `modules/amc/governance-oversight/DEPLOYMENT_STRATEGY_OVERSIGHT.md` | Complete | Formal oversight record. CS2 auth: #1133. |
+| Deployment Execution Strategy | `modules/amc/05a-deployment-execution-strategy/deployment-execution-strategy.md` | 🟡 Approval Pending | v1.0, produced 2026-04-27. CS2 approval required. |
+| Deployment Surface Ownership Table | `modules/amc/05a-deployment-execution-strategy/deployment-surface-ownership-table.md` | 🟡 Approval Pending | v1.0, produced 2026-04-27. |
+| Runner and Environment Constraints | `modules/amc/05a-deployment-execution-strategy/runner-and-environment-constraints.md` | 🟡 Approval Pending | v1.0, produced 2026-04-27. |
+| Functional Delivery Deployment Execution Addendum | `modules/amc/05a-deployment-execution-strategy/functional-delivery-deployment-execution-addendum.md` | 🟡 Retrofit Reference Input | Produced/merged in PR #1190. Imports TR-1910, Stage 5 architecture map, deployment evidence, runtime health/smoke validation, dependency readiness, and no-operational-speculation controls. CS2 disposition required. |
+| Deployment Execution Validation Matrix | `modules/amc/05a-deployment-execution-strategy/deployment-execution-validation-matrix.md` | 🟡 Retrofit Reference Input | Produced/merged in PR #1190. Adds workflow, environment, migration, protected approval, health, rollback, dependency, audit, and evidence validation obligations for Stage 6/7 derivation. CS2 disposition required. |
+| Stage 5a Functional Delivery Change-Propagation Audit | `modules/amc/05a-deployment-execution-strategy/stage5a-functional-delivery-change-propagation-audit.md` | 🟡 Retrofit Reference Input | Produced/merged in PR #1190. Conditional pass for Stage 5a retrofit production; not build-ready and not Stage-8-ready. |
+| Governance Oversight Record | `modules/amc/governance-oversight/DEPLOYMENT_STRATEGY_OVERSIGHT.md` | ✅ Complete | Formal oversight record. CS2 auth: #1133. |
 
 ---
 
@@ -91,14 +91,14 @@ This index catalogs all pre-build artifacts for the AMC module, mapped to their 
 
 | Artifact | Location | Status | Notes |
 |----------|----------|--------|-------|
-| QA-to-Red Specification | `modules/amc/05-qa-to-red/qa-to-red-specification.md` | Approval Pending | v1.0, produced 2026-04-27. Must be reviewed with Stage 6 retrofit artifacts. |
-| Architecture and DES to QA Traceability | `modules/amc/05-qa-to-red/architecture-and-des-to-qa-traceability.md` | Approval Pending | v1.0, produced 2026-04-27. Must be reconciled with Stage 5/5a retrofit maps before Stage 8. |
-| Red Test Catalog | `modules/amc/05-qa-to-red/red-test-catalog.md` | Approval Pending | v1.0, produced 2026-04-27. 79 test cases across 20 families. Retrofit adds QA-FD and QA-DEPLOY families. |
-| Functional Delivery QA-to-Red Addendum | `modules/amc/05-qa-to-red/functional-delivery-qa-to-red-addendum.md` | Retrofit Reference Input | Produced/merged in PR #1192. Imports Stage 1-5a functional-delivery and deployment-execution obligations into Stage 6. |
-| Functional Delivery RED Test Expansion Matrix | `modules/amc/05-qa-to-red/functional-delivery-red-test-expansion-matrix.md` | Retrofit Reference Input | Produced/merged in PR #1192. Defines QA-FD and QA-DEPLOY RED test families. |
-| Stage 6 Functional Delivery Change-Propagation Audit | `modules/amc/05-qa-to-red/stage6-functional-delivery-change-propagation-audit.md` | Retrofit Reference Input | Produced/merged in PR #1192. Conditional pass for Stage 6 retrofit production; not build-ready and not Stage-8-ready. |
-| QA-to-Red Suite (superseded placeholder) | `modules/amc/05-qa-to-red/qa-to-red-suite.md` | Superseded | Placeholder superseded by qa-to-red-specification.md v1.0. |
-| QA Catalog Alignment (superseded placeholder) | `modules/amc/05-qa-to-red/qa-catalog-alignment.md` | Superseded | Placeholder superseded by architecture-and-des-to-qa-traceability.md v1.0. |
+| QA-to-Red Specification | `modules/amc/05-qa-to-red/qa-to-red-specification.md` | 🟡 Approval Pending | v1.0, produced 2026-04-27. Must be reviewed with Stage 6 retrofit artifacts. |
+| Architecture and DES to QA Traceability | `modules/amc/05-qa-to-red/architecture-and-des-to-qa-traceability.md` | 🟡 Approval Pending | v1.0, produced 2026-04-27. Must be reconciled with Stage 5/5a retrofit maps before Stage 8. |
+| Red Test Catalog | `modules/amc/05-qa-to-red/red-test-catalog.md` | 🟡 Approval Pending | v1.0, produced 2026-04-27. 79 test cases across 20 families. Retrofit adds QA-FD and QA-DEPLOY families. |
+| Functional Delivery QA-to-Red Addendum | `modules/amc/05-qa-to-red/functional-delivery-qa-to-red-addendum.md` | 🟡 Retrofit Reference Input | Produced/merged in PR #1192. Imports Stage 1-5a functional-delivery and deployment-execution obligations into Stage 6. CS2 disposition required. |
+| Functional Delivery RED Test Expansion Matrix | `modules/amc/05-qa-to-red/functional-delivery-red-test-expansion-matrix.md` | 🟡 Retrofit Reference Input | Produced/merged in PR #1192. Defines QA-FD and QA-DEPLOY RED test families. CS2 disposition required. |
+| Stage 6 Functional Delivery Change-Propagation Audit | `modules/amc/05-qa-to-red/stage6-functional-delivery-change-propagation-audit.md` | 🟡 Retrofit Reference Input | Produced/merged in PR #1192. Conditional pass for Stage 6 retrofit production; not build-ready and not Stage-8-ready. |
+| QA-to-Red Suite (superseded placeholder) | `modules/amc/05-qa-to-red/qa-to-red-suite.md` | ⛔ Superseded | Placeholder superseded by qa-to-red-specification.md v1.0. |
+| QA Catalog Alignment (superseded placeholder) | `modules/amc/05-qa-to-red/qa-catalog-alignment.md` | ⛔ Superseded | Placeholder superseded by architecture-and-des-to-qa-traceability.md v1.0. |
 
 ---
 
@@ -106,14 +106,14 @@ This index catalogs all pre-build artifacts for the AMC module, mapped to their 
 
 | Artifact | Location | Status | Notes |
 |----------|----------|--------|-------|
-| Pre-Build Final Assurance Gate | `modules/amc/06-pbfag/pre-build-final-assurance-gate.md` | Approval Pending | Must be reconciled with Stage 5/5a/6 retrofit obligations before Stage 8. |
-| PBFAG Evidence Matrix | `modules/amc/06-pbfag/pbfag-evidence-matrix.md` | Approval Pending | Must include tracker/index agreement for new retrofit artifacts before final Stage 8 disposition. |
-| PBFAG Findings and Verdict | `modules/amc/06-pbfag/pbfag-findings-and-verdict.md` | Approval Pending | Stage 8 gate remains conditional. |
-| PBFAG Checklist | `modules/amc/06-pbfag/pbfag-checklist.md` | Approval Pending | References canonical PBFAG artifacts. |
-| Stage 1-4 Functional Delivery Change-Propagation Audit | `modules/amc/06-pbfag/stage1-4-functional-delivery-change-propagation-audit.md` | Retrofit Reference Input | Produced/merged in PR #1186 chain and retained as upstream disposition input. |
-| Functional Delivery PBFAG Addendum | `modules/amc/06-pbfag/functional-delivery-pbfag-addendum.md` | Retrofit Produced for CS2 Review | Produced in issue #1193. Imports Stage 5/5a/6 retrofit obligations into Stage 7. |
-| PBFAG Retrofit Evidence Matrix | `modules/amc/06-pbfag/pbfag-retrofit-evidence-matrix.md` | Retrofit Produced for CS2 Review | Produced in issue #1193. Maps Stage 5/5a/6 obligations to PBFAG gate checks. |
-| Stage 7 Functional Delivery Change-Propagation Audit | `modules/amc/06-pbfag/stage7-functional-delivery-change-propagation-audit.md` | Retrofit Produced for CS2 Review | Produced in issue #1193. Conditional pass for Stage 7 retrofit production; not build-ready and not Stage-8-ready. |
+| Pre-Build Final Assurance Gate | `modules/amc/06-pbfag/pre-build-final-assurance-gate.md` | 🟡 Approval Pending | Must be reconciled with Stage 5/5a/6 retrofit obligations before Stage 8. |
+| PBFAG Evidence Matrix | `modules/amc/06-pbfag/pbfag-evidence-matrix.md` | 🟡 Approval Pending | Must include tracker/index agreement for new retrofit artifacts before final Stage 8 disposition. |
+| PBFAG Findings and Verdict | `modules/amc/06-pbfag/pbfag-findings-and-verdict.md` | 🟡 Approval Pending | Stage 8 gate remains conditional. |
+| PBFAG Checklist | `modules/amc/06-pbfag/pbfag-checklist.md` | 🟡 Approval Pending | References canonical PBFAG artifacts. |
+| Stage 1-4 Functional Delivery Change-Propagation Audit | `modules/amc/06-pbfag/stage1-4-functional-delivery-change-propagation-audit.md` | 🟡 Retrofit Reference Input | Produced/merged in PR #1186 chain and retained as upstream disposition input. CS2 disposition required. |
+| Functional Delivery PBFAG Addendum | `modules/amc/06-pbfag/functional-delivery-pbfag-addendum.md` | 🟡 Retrofit Produced for CS2 Review | Produced in issue #1193 / PR #1194. Imports Stage 5/5a/6 retrofit obligations into Stage 7. |
+| PBFAG Retrofit Evidence Matrix | `modules/amc/06-pbfag/pbfag-retrofit-evidence-matrix.md` | 🟡 Retrofit Produced for CS2 Review | Produced in issue #1193 / PR #1194. Maps Stage 5/5a/6 obligations to PBFAG gate checks. |
+| Stage 7 Functional Delivery Change-Propagation Audit | `modules/amc/06-pbfag/stage7-functional-delivery-change-propagation-audit.md` | 🟡 Retrofit Produced for CS2 Review | Produced in issue #1193 / PR #1194. Conditional pass for Stage 7 retrofit production; not build-ready and not Stage-8-ready. |
 
 ---
 
@@ -121,8 +121,8 @@ This index catalogs all pre-build artifacts for the AMC module, mapped to their 
 
 | Artifact | Location | Status | Notes |
 |----------|----------|--------|-------|
-| Implementation Plan | `modules/amc/07-implementation-plan/implementation-plan.md` | Placeholder | Not started. |
-| Wave Breakdown | `modules/amc/07-implementation-plan/wave-breakdown.md` | Placeholder | Not started. |
+| Implementation Plan | `modules/amc/07-implementation-plan/implementation-plan.md` | ⬜ Placeholder | Not started. |
+| Wave Breakdown | `modules/amc/07-implementation-plan/wave-breakdown.md` | ⬜ Placeholder | Not started. |
 
 ---
 
@@ -130,8 +130,8 @@ This index catalogs all pre-build artifacts for the AMC module, mapped to their 
 
 | Artifact | Location | Status | Notes |
 |----------|----------|--------|-------|
-| Builder Checklist | `modules/amc/08-builder-checklist/builder-checklist.md` | Placeholder | Not started. |
-| Builder Readiness Attestations | `modules/amc/08-builder-checklist/builder-readiness-attestations.md` | Placeholder | Not started. |
+| Builder Checklist | `modules/amc/08-builder-checklist/builder-checklist.md` | ⬜ Placeholder | Not started. |
+| Builder Readiness Attestations | `modules/amc/08-builder-checklist/builder-readiness-attestations.md` | ⬜ Placeholder | Not started. |
 
 ---
 
@@ -139,8 +139,8 @@ This index catalogs all pre-build artifacts for the AMC module, mapped to their 
 
 | Artifact | Location | Status | Notes |
 |----------|----------|--------|-------|
-| IAA Pre-Brief | `modules/amc/09-iaa-pre-brief/iaa-pre-brief.md` | Placeholder | Not started. |
-| IAA Pre-Brief Response | `modules/amc/09-iaa-pre-brief/iaa-pre-brief-response.md` | Placeholder | Not started. |
+| IAA Pre-Brief | `modules/amc/09-iaa-pre-brief/iaa-pre-brief.md` | ⬜ Placeholder | Not started. |
+| IAA Pre-Brief Response | `modules/amc/09-iaa-pre-brief/iaa-pre-brief-response.md` | ⬜ Placeholder | Not started. |
 
 ---
 
@@ -148,8 +148,8 @@ This index catalogs all pre-build artifacts for the AMC module, mapped to their 
 
 | Artifact | Location | Status | Notes |
 |----------|----------|--------|-------|
-| Builder Appointment | `modules/amc/10-builder-appointment/builder-appointment.md` | Placeholder | Not started. |
-| Builder Contract | `modules/amc/10-builder-appointment/builder-contract.md` | Placeholder | Not started. |
+| Builder Appointment | `modules/amc/10-builder-appointment/builder-appointment.md` | ⬜ Placeholder | Not started. |
+| Builder Contract | `modules/amc/10-builder-appointment/builder-contract.md` | ⬜ Placeholder | Not started. |
 
 ---
 
@@ -157,9 +157,9 @@ This index catalogs all pre-build artifacts for the AMC module, mapped to their 
 
 | Artifact | Location | Status | Notes |
 |----------|----------|--------|-------|
-| Build Evidence Index | `modules/amc/11-build/build-evidence-index.md` | Placeholder | Not started. |
-| QA-to-Green Evidence | `modules/amc/11-build/qa-to-green-evidence.md` | Placeholder | Not started. |
-| Handover | `modules/amc/11-build/handover.md` | Placeholder | Not started. |
+| Build Evidence Index | `modules/amc/11-build/build-evidence-index.md` | ⬜ Placeholder | Not started. |
+| QA-to-Green Evidence | `modules/amc/11-build/qa-to-green-evidence.md` | ⬜ Placeholder | Not started. |
+| Handover | `modules/amc/11-build/handover.md` | ⬜ Placeholder | Not started. |
 
 ---
 
@@ -167,4 +167,4 @@ This index catalogs all pre-build artifacts for the AMC module, mapped to their 
 
 | Artifact | Location | Status | Notes |
 |----------|----------|--------|-------|
-| FM-era artifacts | `modules/amc/_legacy/foreman-app-origin/` | Legacy Area | Historical artifacts only. |
+| FM-era artifacts | `modules/amc/_legacy/foreman-app-origin/` | 📦 Legacy Area | Historical artifacts only. |

--- a/modules/amc/AMC_PRE_BUILD_ARTIFACT_INDEX.md
+++ b/modules/amc/AMC_PRE_BUILD_ARTIFACT_INDEX.md
@@ -2,7 +2,7 @@
 
 **Module**: App Management Centre (AMC)  
 **Lifecycle Model**: 12-Stage Pre-Build Sequence + Stage 5a (PRE_BUILD_STAGE_MODEL_CANON.md v1.0.0; AMC-GOV-OVERSIGHT-001)  
-**Last Updated**: 2026-06-29 (Stage 6 QA-to-Red functional-delivery retrofit artifacts produced for CS2 review — wave amc-stage6-qa-to-red-retrofit-20260629; issue #1191; PR #1192. Prior: Stage 5a functional-delivery deployment execution retrofit merged as approval-pending reference input — issue #1189; PR #1190. Prior: Stage 5 architecture functional-delivery retrofit merged as approval-pending reference input — issue #1187; PR #1188. Prior: Stage 1-4 functional-delivery retrofit merged — issue #1185; PR #1186.)  
+**Last Updated**: 2026-06-30 (Stage 7 PBFAG functional-delivery / deployment-execution / QA retrofit artifacts produced for CS2 review - wave amc-stage7-pbfag-retrofit-20260630; issue #1193. Prior: Stage 6 QA-to-Red functional-delivery retrofit merged as approval-pending reference input - issue #1191; PR #1192. Prior: Stage 5a retrofit merged as approval-pending reference input - issue #1189; PR #1190. Prior: Stage 5 architecture retrofit merged as approval-pending reference input - issue #1187; PR #1188. Prior: Stage 1-4 retrofit merged - issue #1185; PR #1186.)  
 **Authority**: Maturion Foreman / CS2
 
 ---
@@ -13,164 +13,153 @@ This index catalogs all pre-build artifacts for the AMC module, mapped to their 
 
 ---
 
-## Stage 1 — App Description
+## Stage 1 - App Description
 
 | Artifact | Location | Status | Notes |
 |----------|----------|--------|-------|
-| App Description | `modules/amc/00-app-description/app-description.md` | ✅ Approved Canonical | v1.0, CS2-approved 2026-04-22. Sole authoritative Stage 1 source. Approval ref: #1117. |
-| App Description Approval | `modules/amc/00-app-description/app-description-approval.md` | ✅ Complete | Formal Stage 1 approval record. |
-| Functional Delivery Definition | `modules/amc/00-app-description/functional-delivery-definition.md` | 🟡 Retrofit Reference Input | Produced/merged in PR #1186. Adds fully functional delivery definition. CS2 disposition required as part of retrofit chain. |
-| AMC Role Authority & Operating Model | `modules/amc/00-app-description/amc-role-authority-and-operating-model.md` | ⬜ Placeholder | Follow-on work required. Does not block Stage 2. |
-| FM App Description (superseded) | `docs/governance/FM_APP_DESCRIPTION.md` | 📦 Superseded | Retained as historical/provenance reference only. No longer the active canonical Stage 1 source. |
-| App Description (root pointer) | `APP_DESCRIPTION.md` | 📌 Reference Only | Follow-on update to point to new canonical location pending. |
+| App Description | `modules/amc/00-app-description/app-description.md` | Approved Canonical | v1.0, CS2-approved 2026-04-22. Sole authoritative Stage 1 source. Approval ref: #1117. |
+| App Description Approval | `modules/amc/00-app-description/app-description-approval.md` | Complete | Formal Stage 1 approval record. |
+| Functional Delivery Definition | `modules/amc/00-app-description/functional-delivery-definition.md` | Retrofit Reference Input | Produced/merged in PR #1186. Adds fully functional delivery definition. CS2 disposition required as part of retrofit chain. |
+| AMC Role Authority & Operating Model | `modules/amc/00-app-description/amc-role-authority-and-operating-model.md` | Placeholder | Follow-on work required. Does not block Stage 2. |
+| FM App Description (superseded) | `docs/governance/FM_APP_DESCRIPTION.md` | Superseded | Retained as historical/provenance reference only. |
+| App Description (root pointer) | `APP_DESCRIPTION.md` | Reference Only | Follow-on update to point to canonical location pending. |
 
 ---
 
-## Stage 2 — UX Workflow & Wiring Spec
+## Stage 2 - UX Workflow & Wiring Spec
 
 | Artifact | Location | Status | Notes |
 |----------|----------|--------|-------|
-| UX Workflow & Wiring Spec | `modules/amc/01-ux-workflow-wiring-spec/ux-workflow-wiring-spec.md` | ✅ Approved Canonical | v1.1, CS2-approved 2026-04-22. |
-| Wiring Artifact Index | `modules/amc/01-ux-workflow-wiring-spec/wiring-artifact-index.md` | ✅ Approved Canonical | v1.0, CS2-approved 2026-04-22. |
-| CTA/API/Data/Audit Contract Matrix | `modules/amc/01-ux-workflow-wiring-spec/cta-api-data-audit-contract-matrix.md` | 🟡 Retrofit Reference Input | Produced/merged in PR #1186. Canonical endpoint/event authority remains with Stage 4 TRS. |
+| UX Workflow & Wiring Spec | `modules/amc/01-ux-workflow-wiring-spec/ux-workflow-wiring-spec.md` | Approved Canonical | v1.1, CS2-approved 2026-04-22. |
+| Wiring Artifact Index | `modules/amc/01-ux-workflow-wiring-spec/wiring-artifact-index.md` | Approved Canonical | v1.0, CS2-approved 2026-04-22. |
+| CTA/API/Data/Audit Contract Matrix | `modules/amc/01-ux-workflow-wiring-spec/cta-api-data-audit-contract-matrix.md` | Retrofit Reference Input | Produced/merged in PR #1186. Canonical endpoint/event authority remains with Stage 4 TRS. |
 
 ---
 
-## Stage 3 — FRS
+## Stage 3 - FRS
 
 | Artifact | Location | Status | Notes |
 |----------|----------|--------|-------|
-| Functional Requirements Specification | `modules/amc/02-frs/functional-requirements-specification.md` | ✅ Approved Canonical | v1.1, CS2-approved for Stage 4 progression 2026-04-23. |
-| App Description to FRS Traceability | `modules/amc/02-frs/app-description-to-frs-traceability.md` | ✅ Approved Canonical | v1.0, CS2-approved for Stage 4 progression 2026-04-23. |
-| Functional Delivery Requirements Addendum | `modules/amc/02-frs/functional-delivery-requirements-addendum.md` | 🟡 Retrofit Reference Input | FR-1900 produced/merged in PR #1186. CS2 disposition required as part of retrofit chain. |
+| Functional Requirements Specification | `modules/amc/02-frs/functional-requirements-specification.md` | Approved Canonical | v1.1, CS2-approved for Stage 4 progression 2026-04-23. |
+| App Description to FRS Traceability | `modules/amc/02-frs/app-description-to-frs-traceability.md` | Approved Canonical | v1.0, CS2-approved for Stage 4 progression 2026-04-23. |
+| Functional Delivery Requirements Addendum | `modules/amc/02-frs/functional-delivery-requirements-addendum.md` | Retrofit Reference Input | FR-1900 produced/merged in PR #1186. |
 
 ---
 
-## Stage 4 — TRS
+## Stage 4 - TRS
 
 | Artifact | Location | Status | Notes |
 |----------|----------|--------|-------|
-| Technical Requirements Specification | `modules/amc/03-trs/technical-requirements-specification.md` | 🟠 Treated as Approved | v1.1, hardened approval-ready 2026-04-23. Formal CS2 approval pending. |
-| FRS to TRS Traceability | `modules/amc/03-trs/frs-to-trs-traceability.md` | 🟠 Treated as Approved | v1.1, hardened 2026-04-23. |
-| Functional Delivery Technical Requirements Addendum | `modules/amc/03-trs/functional-delivery-technical-requirements-addendum.md` | 🟡 Retrofit Reference Input | TR-1900, including TR-1910, produced/merged in PR #1186. CS2 disposition required as part of retrofit chain. |
+| Technical Requirements Specification | `modules/amc/03-trs/technical-requirements-specification.md` | Treated as Approved | v1.1, hardened approval-ready 2026-04-23. Formal CS2 approval pending. |
+| FRS to TRS Traceability | `modules/amc/03-trs/frs-to-trs-traceability.md` | Treated as Approved | v1.1, hardened 2026-04-23. |
+| Functional Delivery Technical Requirements Addendum | `modules/amc/03-trs/functional-delivery-technical-requirements-addendum.md` | Retrofit Reference Input | TR-1900, including TR-1910, produced/merged in PR #1186. |
 
 ---
 
-## Stage 5 — Architecture
+## Stage 5 - Architecture
 
 | Artifact | Location | Status | Notes |
 |----------|----------|--------|-------|
-| Architecture Specification | `modules/amc/04-architecture/architecture-specification.md` | 🟡 Approval Pending | v1.0, produced 2026-04-26. CS2 approval required. |
-| TRS-to-Architecture Traceability | `modules/amc/04-architecture/trs-to-architecture-traceability.md` | 🟡 Approval Pending | v1.0, produced 2026-04-26. |
-| Functional Delivery Architecture Addendum | `modules/amc/04-architecture/functional-delivery-architecture-addendum.md` | 🟡 Retrofit Reference Input | Produced/merged in PR #1188. CS2 disposition required. |
-| Functional Delivery Architecture Map | `modules/amc/04-architecture/functional-delivery-architecture-map.md` | 🟡 Retrofit Reference Input | Produced/merged in PR #1188. Route/action/state/audit/degraded-mode map for Stage 6 derivation. |
-| Stage 5 Functional Delivery Change-Propagation Audit | `modules/amc/04-architecture/stage5-functional-delivery-change-propagation-audit.md` | 🟡 Retrofit Reference Input | Produced/merged in PR #1188. Conditional pass for retrofit production; not build-ready and not Stage-8-ready. |
-| Stage 5 Review Notes | `modules/amc/04-architecture/stage5-review-notes.md` | 🟡 Retrofit Reference Input | Produced/merged in PR #1188. |
-| Stage 5 Coverage Note | `modules/amc/04-architecture/extra-review-note.md` | 🟡 Retrofit Reference Input | Produced/merged in PR #1188. |
-| Architecture (superseded placeholder) | `modules/amc/04-architecture/architecture.md` | 📦 Superseded | `architecture-specification.md` is the canonical Stage 5 artifact. |
-| Architecture Decision Records | `modules/amc/04-architecture/architecture-decision-records.md` | ⬜ Placeholder | Not started. |
-| Architecture Completeness Checklist | `modules/amc/04-architecture/architecture-completeness-checklist.md` | ⬜ Placeholder | Not started / remains a placeholder unless separately populated. |
+| Architecture Specification | `modules/amc/04-architecture/architecture-specification.md` | Approval Pending | v1.0, produced 2026-04-26. CS2 approval required. |
+| TRS-to-Architecture Traceability | `modules/amc/04-architecture/trs-to-architecture-traceability.md` | Approval Pending | v1.0, produced 2026-04-26. |
+| Functional Delivery Architecture Addendum | `modules/amc/04-architecture/functional-delivery-architecture-addendum.md` | Retrofit Reference Input | Produced/merged in PR #1188. |
+| Functional Delivery Architecture Map | `modules/amc/04-architecture/functional-delivery-architecture-map.md` | Retrofit Reference Input | Produced/merged in PR #1188. Route/action/state/audit/degraded-mode map for Stage 6/7 derivation. |
+| Stage 5 Functional Delivery Change-Propagation Audit | `modules/amc/04-architecture/stage5-functional-delivery-change-propagation-audit.md` | Retrofit Reference Input | Produced/merged in PR #1188. Conditional pass for retrofit production; not build-ready and not Stage-8-ready. |
+| Stage 5 Review Notes | `modules/amc/04-architecture/stage5-review-notes.md` | Retrofit Reference Input | Produced/merged in PR #1188. |
+| Stage 5 Coverage Note | `modules/amc/04-architecture/extra-review-note.md` | Retrofit Reference Input | Produced/merged in PR #1188. |
+| Architecture (superseded placeholder) | `modules/amc/04-architecture/architecture.md` | Superseded | `architecture-specification.md` is the canonical Stage 5 artifact. |
+| Architecture Decision Records | `modules/amc/04-architecture/architecture-decision-records.md` | Placeholder | Not started. |
+| Architecture Completeness Checklist | `modules/amc/04-architecture/architecture-completeness-checklist.md` | Placeholder | Not started / remains a placeholder unless separately populated. |
 
 ---
 
-## Stage 5a — Deployment Execution Strategy *(AMC-local mandatory stage)*
-
-> **Stage 5a Definition Authority**: `modules/amc/governance-oversight/DEPLOYMENT_STRATEGY_OVERSIGHT.md` (AMC-GOV-OVERSIGHT-001 v1.0)  
-> **Status**: 🟡 Retrofit merged as reference input — CS2 review/disposition pending  
-> **Blocks**: Stage 6 retrofit/disposition, Stage 7 final disposition, Stage 8, and all subsequent build-readiness activities.
+## Stage 5a - Deployment Execution Strategy
 
 | Artifact | Location | Status | Notes |
 |----------|----------|--------|-------|
-| Deployment Execution Strategy | `modules/amc/05a-deployment-execution-strategy/deployment-execution-strategy.md` | 🟡 Approval Pending | v1.0, produced 2026-04-27. CS2 approval required. |
-| Deployment Surface Ownership Table | `modules/amc/05a-deployment-execution-strategy/deployment-surface-ownership-table.md` | 🟡 Approval Pending | v1.0, produced 2026-04-27. |
-| Runner and Environment Constraints | `modules/amc/05a-deployment-execution-strategy/runner-and-environment-constraints.md` | 🟡 Approval Pending | v1.0, produced 2026-04-27. |
-| Functional Delivery Deployment Execution Addendum | `modules/amc/05a-deployment-execution-strategy/functional-delivery-deployment-execution-addendum.md` | 🟡 Retrofit Reference Input | Produced/merged in PR #1190. Imports TR-1910, Stage 5 architecture map, deployment evidence, runtime health/smoke validation, dependency readiness, and no-operational-speculation controls. |
-| Deployment Execution Validation Matrix | `modules/amc/05a-deployment-execution-strategy/deployment-execution-validation-matrix.md` | 🟡 Retrofit Reference Input | Produced/merged in PR #1190. Adds workflow, environment, migration, protected approval, health, rollback, dependency, audit, and evidence validation obligations for Stage 6/7 derivation. |
-| Stage 5a Functional Delivery Change-Propagation Audit | `modules/amc/05a-deployment-execution-strategy/stage5a-functional-delivery-change-propagation-audit.md` | 🟡 Retrofit Reference Input | Produced/merged in PR #1190. Conditional pass for Stage 5a retrofit production; not build-ready and not Stage-8-ready. |
-| Governance Oversight Record | `modules/amc/governance-oversight/DEPLOYMENT_STRATEGY_OVERSIGHT.md` | ✅ COMPLETE — v1.0 | Formal oversight record. CS2 auth: #1133. |
+| Deployment Execution Strategy | `modules/amc/05a-deployment-execution-strategy/deployment-execution-strategy.md` | Approval Pending | v1.0, produced 2026-04-27. CS2 approval required. |
+| Deployment Surface Ownership Table | `modules/amc/05a-deployment-execution-strategy/deployment-surface-ownership-table.md` | Approval Pending | v1.0, produced 2026-04-27. |
+| Runner and Environment Constraints | `modules/amc/05a-deployment-execution-strategy/runner-and-environment-constraints.md` | Approval Pending | v1.0, produced 2026-04-27. |
+| Functional Delivery Deployment Execution Addendum | `modules/amc/05a-deployment-execution-strategy/functional-delivery-deployment-execution-addendum.md` | Retrofit Reference Input | Produced/merged in PR #1190. Imports TR-1910, Stage 5 architecture map, deployment evidence, runtime health/smoke validation, dependency readiness, and no-operational-speculation controls. |
+| Deployment Execution Validation Matrix | `modules/amc/05a-deployment-execution-strategy/deployment-execution-validation-matrix.md` | Retrofit Reference Input | Produced/merged in PR #1190. Adds workflow, environment, migration, protected approval, health, rollback, dependency, audit, and evidence validation obligations for Stage 6/7 derivation. |
+| Stage 5a Functional Delivery Change-Propagation Audit | `modules/amc/05a-deployment-execution-strategy/stage5a-functional-delivery-change-propagation-audit.md` | Retrofit Reference Input | Produced/merged in PR #1190. Conditional pass for Stage 5a retrofit production; not build-ready and not Stage-8-ready. |
+| Governance Oversight Record | `modules/amc/governance-oversight/DEPLOYMENT_STRATEGY_OVERSIGHT.md` | Complete | Formal oversight record. CS2 auth: #1133. |
 
 ---
 
-## Stage 6 — QA-to-Red
-
-> **Current Retrofit Issue**: app_management_centre#1191  
-> **Current Retrofit PR**: app_management_centre#1192  
-> **Status**: 🟡 Retrofit produced — CS2 review/disposition pending  
-> **Blocks**: Stage 7 final disposition, Stage 8, and all subsequent build-readiness activities.
+## Stage 6 - QA-to-Red
 
 | Artifact | Location | Status | Notes |
 |----------|----------|--------|-------|
-| QA-to-Red Specification | `modules/amc/05-qa-to-red/qa-to-red-specification.md` | 🟡 Approval Pending | v1.0, produced 2026-04-27. Must be reviewed with Stage 6 retrofit artifacts. |
-| Architecture and DES to QA Traceability | `modules/amc/05-qa-to-red/architecture-and-des-to-qa-traceability.md` | 🟡 Approval Pending | v1.0, produced 2026-04-27. Must be reconciled with Stage 5/5a retrofit maps before Stage 8. |
-| Red Test Catalog | `modules/amc/05-qa-to-red/red-test-catalog.md` | 🟡 Approval Pending | v1.0, produced 2026-04-27. 79 test cases across 20 families. Retrofit adds QA-FD and QA-DEPLOY families. |
-| Functional Delivery QA-to-Red Addendum | `modules/amc/05-qa-to-red/functional-delivery-qa-to-red-addendum.md` | 🟡 Retrofit Produced for CS2 Review | Produced in issue #1191 / PR #1192. Imports Stage 1-5a functional-delivery and deployment-execution obligations into Stage 6. |
-| Functional Delivery RED Test Expansion Matrix | `modules/amc/05-qa-to-red/functional-delivery-red-test-expansion-matrix.md` | 🟡 Retrofit Produced for CS2 Review | Produced in issue #1191 / PR #1192. Defines QA-FD and QA-DEPLOY RED test families. |
-| Stage 6 Functional Delivery Change-Propagation Audit | `modules/amc/05-qa-to-red/stage6-functional-delivery-change-propagation-audit.md` | 🟡 Retrofit Produced for CS2 Review | Produced in issue #1191 / PR #1192. Conditional pass for Stage 6 retrofit production; not build-ready and not Stage-8-ready. |
-| QA-to-Red Suite (superseded placeholder) | `modules/amc/05-qa-to-red/qa-to-red-suite.md` | ⛔ Superseded | Placeholder superseded by qa-to-red-specification.md v1.0. |
-| QA Catalog Alignment (superseded placeholder) | `modules/amc/05-qa-to-red/qa-catalog-alignment.md` | ⛔ Superseded | Placeholder superseded by architecture-and-des-to-qa-traceability.md v1.0. |
-
-> **Gate condition**: Stage 7 / Stage 8 remain blocked until Stage 5, Stage 5a, Stage 6, and Stage 7 are CS2-dispositioned. Stage 6 must import Stage 5/5a retrofit obligations before Stage 8 planning.
+| QA-to-Red Specification | `modules/amc/05-qa-to-red/qa-to-red-specification.md` | Approval Pending | v1.0, produced 2026-04-27. Must be reviewed with Stage 6 retrofit artifacts. |
+| Architecture and DES to QA Traceability | `modules/amc/05-qa-to-red/architecture-and-des-to-qa-traceability.md` | Approval Pending | v1.0, produced 2026-04-27. Must be reconciled with Stage 5/5a retrofit maps before Stage 8. |
+| Red Test Catalog | `modules/amc/05-qa-to-red/red-test-catalog.md` | Approval Pending | v1.0, produced 2026-04-27. 79 test cases across 20 families. Retrofit adds QA-FD and QA-DEPLOY families. |
+| Functional Delivery QA-to-Red Addendum | `modules/amc/05-qa-to-red/functional-delivery-qa-to-red-addendum.md` | Retrofit Reference Input | Produced/merged in PR #1192. Imports Stage 1-5a functional-delivery and deployment-execution obligations into Stage 6. |
+| Functional Delivery RED Test Expansion Matrix | `modules/amc/05-qa-to-red/functional-delivery-red-test-expansion-matrix.md` | Retrofit Reference Input | Produced/merged in PR #1192. Defines QA-FD and QA-DEPLOY RED test families. |
+| Stage 6 Functional Delivery Change-Propagation Audit | `modules/amc/05-qa-to-red/stage6-functional-delivery-change-propagation-audit.md` | Retrofit Reference Input | Produced/merged in PR #1192. Conditional pass for Stage 6 retrofit production; not build-ready and not Stage-8-ready. |
+| QA-to-Red Suite (superseded placeholder) | `modules/amc/05-qa-to-red/qa-to-red-suite.md` | Superseded | Placeholder superseded by qa-to-red-specification.md v1.0. |
+| QA Catalog Alignment (superseded placeholder) | `modules/amc/05-qa-to-red/qa-catalog-alignment.md` | Superseded | Placeholder superseded by architecture-and-des-to-qa-traceability.md v1.0. |
 
 ---
 
-## Stage 7 — PBFAG
-
-> **Stage 7 Governing Delivery Issue**: app_management_centre#1152  
-> **Status**: 🟡 Artifacts produced — CS2 approval pending  
-> **Blocks**: Stage 8 and all subsequent stages
+## Stage 7 - PBFAG
 
 | Artifact | Location | Status | Notes |
 |----------|----------|--------|-------|
-| Pre-Build Final Assurance Gate | `modules/amc/06-pbfag/pre-build-final-assurance-gate.md` | 🟡 Approval Pending | Must be reconciled with Stage 5/5a/6 retrofit obligations before Stage 8. |
-| PBFAG Evidence Matrix | `modules/amc/06-pbfag/pbfag-evidence-matrix.md` | 🟡 Approval Pending | Must include tracker/index agreement for new retrofit artifacts before final Stage 8 disposition. |
-| PBFAG Findings and Verdict | `modules/amc/06-pbfag/pbfag-findings-and-verdict.md` | 🟡 Approval Pending | Stage 8 gate remains conditional. |
-| PBFAG Checklist | `modules/amc/06-pbfag/pbfag-checklist.md` | 🟡 Active Wave | References canonical PBFAG artifacts. |
+| Pre-Build Final Assurance Gate | `modules/amc/06-pbfag/pre-build-final-assurance-gate.md` | Approval Pending | Must be reconciled with Stage 5/5a/6 retrofit obligations before Stage 8. |
+| PBFAG Evidence Matrix | `modules/amc/06-pbfag/pbfag-evidence-matrix.md` | Approval Pending | Must include tracker/index agreement for new retrofit artifacts before final Stage 8 disposition. |
+| PBFAG Findings and Verdict | `modules/amc/06-pbfag/pbfag-findings-and-verdict.md` | Approval Pending | Stage 8 gate remains conditional. |
+| PBFAG Checklist | `modules/amc/06-pbfag/pbfag-checklist.md` | Approval Pending | References canonical PBFAG artifacts. |
+| Stage 1-4 Functional Delivery Change-Propagation Audit | `modules/amc/06-pbfag/stage1-4-functional-delivery-change-propagation-audit.md` | Retrofit Reference Input | Produced/merged in PR #1186 chain and retained as upstream disposition input. |
+| Functional Delivery PBFAG Addendum | `modules/amc/06-pbfag/functional-delivery-pbfag-addendum.md` | Retrofit Produced for CS2 Review | Produced in issue #1193. Imports Stage 5/5a/6 retrofit obligations into Stage 7. |
+| PBFAG Retrofit Evidence Matrix | `modules/amc/06-pbfag/pbfag-retrofit-evidence-matrix.md` | Retrofit Produced for CS2 Review | Produced in issue #1193. Maps Stage 5/5a/6 obligations to PBFAG gate checks. |
+| Stage 7 Functional Delivery Change-Propagation Audit | `modules/amc/06-pbfag/stage7-functional-delivery-change-propagation-audit.md` | Retrofit Produced for CS2 Review | Produced in issue #1193. Conditional pass for Stage 7 retrofit production; not build-ready and not Stage-8-ready. |
 
 ---
 
-## Stage 8 — Implementation Plan
+## Stage 8 - Implementation Plan
 
 | Artifact | Location | Status | Notes |
 |----------|----------|--------|-------|
-| Implementation Plan | `modules/amc/07-implementation-plan/implementation-plan.md` | ⬜ Placeholder | Not started. |
-| Wave Breakdown | `modules/amc/07-implementation-plan/wave-breakdown.md` | ⬜ Placeholder | Not started. |
+| Implementation Plan | `modules/amc/07-implementation-plan/implementation-plan.md` | Placeholder | Not started. |
+| Wave Breakdown | `modules/amc/07-implementation-plan/wave-breakdown.md` | Placeholder | Not started. |
 
 ---
 
-## Stage 9 — Builder Checklist
+## Stage 9 - Builder Checklist
 
 | Artifact | Location | Status | Notes |
 |----------|----------|--------|-------|
-| Builder Checklist | `modules/amc/08-builder-checklist/builder-checklist.md` | ⬜ Placeholder | Not started. |
-| Builder Readiness Attestations | `modules/amc/08-builder-checklist/builder-readiness-attestations.md` | ⬜ Placeholder | Not started. |
+| Builder Checklist | `modules/amc/08-builder-checklist/builder-checklist.md` | Placeholder | Not started. |
+| Builder Readiness Attestations | `modules/amc/08-builder-checklist/builder-readiness-attestations.md` | Placeholder | Not started. |
 
 ---
 
-## Stage 10 — IAA Pre-Brief
+## Stage 10 - IAA Pre-Brief
 
 | Artifact | Location | Status | Notes |
 |----------|----------|--------|-------|
-| IAA Pre-Brief | `modules/amc/09-iaa-pre-brief/iaa-pre-brief.md` | ⬜ Placeholder | Not started. |
-| IAA Pre-Brief Response | `modules/amc/09-iaa-pre-brief/iaa-pre-brief-response.md` | ⬜ Placeholder | Not started. |
+| IAA Pre-Brief | `modules/amc/09-iaa-pre-brief/iaa-pre-brief.md` | Placeholder | Not started. |
+| IAA Pre-Brief Response | `modules/amc/09-iaa-pre-brief/iaa-pre-brief-response.md` | Placeholder | Not started. |
 
 ---
 
-## Stage 11 — Builder Appointment
+## Stage 11 - Builder Appointment
 
 | Artifact | Location | Status | Notes |
 |----------|----------|--------|-------|
-| Builder Appointment | `modules/amc/10-builder-appointment/builder-appointment.md` | ⬜ Placeholder | Not started. |
-| Builder Contract | `modules/amc/10-builder-appointment/builder-contract.md` | ⬜ Placeholder | Not started. |
+| Builder Appointment | `modules/amc/10-builder-appointment/builder-appointment.md` | Placeholder | Not started. |
+| Builder Contract | `modules/amc/10-builder-appointment/builder-contract.md` | Placeholder | Not started. |
 
 ---
 
-## Stage 12 — Build
+## Stage 12 - Build
 
 | Artifact | Location | Status | Notes |
 |----------|----------|--------|-------|
-| Build Evidence Index | `modules/amc/11-build/build-evidence-index.md` | ⬜ Placeholder | Not started. |
-| QA-to-Green Evidence | `modules/amc/11-build/qa-to-green-evidence.md` | ⬜ Placeholder | Not started. |
-| Handover | `modules/amc/11-build/handover.md` | ⬜ Placeholder | Not started. |
+| Build Evidence Index | `modules/amc/11-build/build-evidence-index.md` | Placeholder | Not started. |
+| QA-to-Green Evidence | `modules/amc/11-build/qa-to-green-evidence.md` | Placeholder | Not started. |
+| Handover | `modules/amc/11-build/handover.md` | Placeholder | Not started. |
 
 ---
 
@@ -178,8 +167,4 @@ This index catalogs all pre-build artifacts for the AMC module, mapped to their 
 
 | Artifact | Location | Status | Notes |
 |----------|----------|--------|-------|
-| FM-era artifacts | `modules/amc/_legacy/foreman-app-origin/` | 📦 Legacy Area | Historical artifacts only. |
-
----
-
-**Legend**: ✅ Active/Complete | 🟡 Approval Pending / Retrofit Produced | 🟠 Treated as Approved | 📌 Reference Only | ⬜ Placeholder/Not Started | 📦 Legacy Area | ⛔ Superseded
+| FM-era artifacts | `modules/amc/_legacy/foreman-app-origin/` | Legacy Area | Historical artifacts only. |

--- a/modules/amc/AMC_PRE_BUILD_ARTIFACT_INDEX.md
+++ b/modules/amc/AMC_PRE_BUILD_ARTIFACT_INDEX.md
@@ -2,7 +2,7 @@
 
 **Module**: App Management Centre (AMC)  
 **Lifecycle Model**: 12-Stage Pre-Build Sequence + Stage 5a (PRE_BUILD_STAGE_MODEL_CANON.md v1.0.0; AMC-GOV-OVERSIGHT-001)  
-**Last Updated**: 2026-06-30 (Stage 7 PBFAG functional-delivery / deployment-execution / QA retrofit artifacts produced for CS2 review - wave amc-stage7-pbfag-retrofit-20260630; issue #1193; PR #1194. Prior: Stage 6 QA-to-Red functional-delivery retrofit merged as approval-pending reference input - issue #1191; PR #1192. Prior: Stage 5a retrofit merged as approval-pending reference input - issue #1189; PR #1190. Prior: Stage 5 architecture retrofit merged as approval-pending reference input - issue #1187; PR #1188. Prior: Stage 1-4 retrofit merged - issue #1185; PR #1186.)  
+**Last Updated**: 2026-07-01 (CS2 disposition pack for Stages 5, 5a, 6, and 7 added for review - PR #1194. Stage 7 PBFAG functional-delivery / deployment-execution / QA retrofit artifacts produced for CS2 review - wave amc-stage7-pbfag-retrofit-20260630; issue #1193; PR #1194. Prior: Stage 6 QA-to-Red functional-delivery retrofit merged as approval-pending reference input - issue #1191; PR #1192. Prior: Stage 5a retrofit merged as approval-pending reference input - issue #1189; PR #1190. Prior: Stage 5 architecture retrofit merged as approval-pending reference input - issue #1187; PR #1188. Prior: Stage 1-4 retrofit merged - issue #1185; PR #1186.)  
 **Authority**: Maturion Foreman / CS2
 
 ---
@@ -114,6 +114,7 @@ This index catalogs all pre-build artifacts for the AMC module, mapped to their 
 | Functional Delivery PBFAG Addendum | `modules/amc/06-pbfag/functional-delivery-pbfag-addendum.md` | 🟡 Retrofit Produced for CS2 Review | Produced in issue #1193 / PR #1194. Imports Stage 5/5a/6 retrofit obligations into Stage 7. |
 | PBFAG Retrofit Evidence Matrix | `modules/amc/06-pbfag/pbfag-retrofit-evidence-matrix.md` | 🟡 Retrofit Produced for CS2 Review | Produced in issue #1193 / PR #1194. Maps Stage 5/5a/6 obligations to PBFAG gate checks. |
 | Stage 7 Functional Delivery Change-Propagation Audit | `modules/amc/06-pbfag/stage7-functional-delivery-change-propagation-audit.md` | 🟡 Retrofit Produced for CS2 Review | Produced in issue #1193 / PR #1194. Conditional pass for Stage 7 retrofit production; not build-ready and not Stage-8-ready. |
+| CS2 Disposition Pack - Stages 5, 5a, 6, and 7 | `modules/amc/06-pbfag/cs2-disposition-pack-stages-5-5a-6-7.md` | 🟡 Prepared for CS2 Review | Produced in PR #1194. Summarises readiness, blockers, risks, conditions, and recommended CS2 disposition. Does not authorize Stage 8. |
 
 ---
 

--- a/modules/amc/BUILD_PROGRESS_TRACKER.md
+++ b/modules/amc/BUILD_PROGRESS_TRACKER.md
@@ -2,8 +2,8 @@
 
 **Module**: App Management Centre (AMC)  
 **Module Slug**: AMC  
-**Last Updated**: 2026-06-30  
-**Updated By**: foreman-v2-agent (wave: amc-stage7-pbfag-retrofit-20260630 - issue #1193; PR #1194; Stage 7 PBFAG retrofit active. PR #1192 is merged. Stage 8 and all build-readiness stages remain blocked.)
+**Last Updated**: 2026-07-01  
+**Updated By**: foreman-v2-agent (wave: amc-stage7-pbfag-retrofit-20260630 - issue #1193; PR #1194; CS2 disposition pack for Stages 5, 5a, 6, and 7 prepared. Stage 8 and all build-readiness stages remain blocked.)
 
 > **Classification**: ACTIVE  
 > **Document Role**: PRIMARY LIVE CONTROL DOCUMENT - CS2 should use this document as the main live progress dashboard.  
@@ -19,6 +19,7 @@
 - PR #1190 merged Stage 5a deployment-execution retrofit reference inputs. Stage 5a remains approval-pending.
 - PR #1192 merged Stage 6 QA-to-Red retrofit reference inputs. Stage 6 remains approval-pending.
 - Issue #1193 / PR #1194 imports Stage 5 route/action/state/audit/degraded-mode obligations, Stage 5a deployment-execution obligations, and Stage 6 QA-FD / QA-DEPLOY obligations into Stage 7 PBFAG.
+- PR #1194 now includes `cs2-disposition-pack-stages-5-5a-6-7.md` to support CS2 disposition of Stages 5, 5a, 6, and 7 without starting Stage 8.
 
 ---
 
@@ -30,11 +31,11 @@
 | 2 | UX Workflow & Wiring Spec | ✅ COMPLETE + 🟡 RETROFIT ADDENDUM PRODUCED | CS2-approved 2026-04-22. CTA/API/Data/Audit matrix merged in #1186. |
 | 3 | FRS | ✅ COMPLETE - CS2 APPROVED + 🟡 RETROFIT ADDENDUM PRODUCED | FR-1900 merged in #1186. |
 | 4 | TRS | ✅ TREATED AS APPROVED + 🟡 RETROFIT ADDENDUM PRODUCED | TR-1900, including TR-1910, merged in #1186. |
-| 5 | Architecture | 🟡 IN PROGRESS — Produced Approval-Pending | PR #1188 merged retrofit inputs; merge is not Stage 5 approval. |
-| 5a | Deployment Execution Strategy | 🟡 IN PROGRESS — Produced Approval-Pending | PR #1190 merged retrofit inputs; merge is not Stage 5a approval. |
-| 6 | QA-to-Red | 🟡 IN PROGRESS — Produced Approval-Pending | PR #1192 merged retrofit inputs; merge is not Stage 6 approval. |
-| **7** | **PBFAG** | **🟡 IN PROGRESS — Produced Approval-Pending** | PR #1194 imports Stage 5/5a/6 retrofit controls as hard PBFAG gates. |
-| 8 | Implementation Plan | ⬜ Not Started — 🔴 BLOCKED | Must not start until Stages 5, 5a, 6, and 7 are CS2-dispositioned. |
+| 5 | Architecture | 🟡 IN PROGRESS — Produced Approval-Pending | Ready for CS2 disposition via PR #1194 pack; merge is not Stage 5 approval. |
+| 5a | Deployment Execution Strategy | 🟡 IN PROGRESS — Produced Approval-Pending | Ready for CS2 disposition via PR #1194 pack; merge is not Stage 5a approval. |
+| 6 | QA-to-Red | 🟡 IN PROGRESS — Produced Approval-Pending | Ready for CS2 disposition via PR #1194 pack; merge is not Stage 6 approval. |
+| **7** | **PBFAG** | **🟡 IN PROGRESS — Produced Approval-Pending** | PR #1194 imports Stage 5/5a/6 retrofit controls and includes CS2 disposition pack. |
+| 8 | Implementation Plan | ⬜ Not Started — 🔴 BLOCKED | Must not start until Stages 5, 5a, 6, and 7 are CS2-dispositioned by explicit CS2 action. |
 | 9 | Builder Checklist | ⬜ Not Started — 🔴 BLOCKED | Blocked until Stage 8 is authorized and complete. |
 | 10 | IAA Pre-Brief | ⬜ Not Started — 🔴 BLOCKED | Blocked until canonical sequence authorizes it. |
 | 11 | Builder Appointment | ⬜ Not Started — 🔴 BLOCKED | No builders appointed. |
@@ -59,8 +60,9 @@
 - [x] `functional-delivery-pbfag-addendum.md` - produced in issue #1193 / PR #1194
 - [x] `pbfag-retrofit-evidence-matrix.md` - produced in issue #1193 / PR #1194
 - [x] `stage7-functional-delivery-change-propagation-audit.md` - produced in issue #1193 / PR #1194
+- [x] `cs2-disposition-pack-stages-5-5a-6-7.md` - produced in PR #1194 for CS2 disposition review
 
-**Current gate note**: Stage 7 must import Stage 5/5a/6 retrofit obligations and fail or condition Stage 8 if material action coverage, deployment execution, route/event authority, evidence package, QA coverage, or placeholder controls remain unresolved. This tracker update does not approve Stage 7.
+**Current gate note**: Stage 7 must import Stage 5/5a/6 retrofit obligations and fail or condition Stage 8 if material action coverage, deployment execution, route/event authority, evidence package, QA coverage, or placeholder controls remain unresolved. This tracker update does not approve Stage 7 or authorize Stage 8.
 
 ---
 
@@ -76,8 +78,8 @@
 
 ## Next Action
 
-1. Review PR #1194 for Stage 7 PBFAG functional-delivery / deployment-execution / QA alignment.
-2. CS2 to disposition whether the existing Stage 7 PBFAG pack may be approved with Stage 5, Stage 5a, and Stage 6 retrofit obligations attached.
+1. Review PR #1194 including the CS2 disposition pack.
+2. CS2 to disposition Stages 5, 5a, 6, and 7 explicitly.
 3. Do not start Stage 8 from this PR.
 4. Do not appoint builders until the canonical pre-build sequence authorizes Stage 11.
 
@@ -95,4 +97,5 @@
 - [functional-delivery-pbfag-addendum.md](./06-pbfag/functional-delivery-pbfag-addendum.md)
 - [pbfag-retrofit-evidence-matrix.md](./06-pbfag/pbfag-retrofit-evidence-matrix.md)
 - [stage7-functional-delivery-change-propagation-audit.md](./06-pbfag/stage7-functional-delivery-change-propagation-audit.md)
+- [cs2-disposition-pack-stages-5-5a-6-7.md](./06-pbfag/cs2-disposition-pack-stages-5-5a-6-7.md)
 - [AMC_PRE_BUILD_ARTIFACT_INDEX.md](./AMC_PRE_BUILD_ARTIFACT_INDEX.md)

--- a/modules/amc/BUILD_PROGRESS_TRACKER.md
+++ b/modules/amc/BUILD_PROGRESS_TRACKER.md
@@ -10,7 +10,7 @@
 > **Canon Reference**: `PRE_BUILD_STAGE_MODEL_CANON.md` v1.0.0 plus current ISMS/MMM functional-delivery retrofit lessons  
 > **Current Issue**: [app_management_centre#1193](https://github.com/APGI-cmy/app_management_centre/issues/1193)  
 > **Current PR**: [app_management_centre#1194](https://github.com/APGI-cmy/app_management_centre/pull/1194)  
-> **Update Rule**: This document MUST be updated after every AMC stage issue, wave completion, approval, or readiness/blocker change.
+> **Update Rule**: This document MUST be updated immediately after every AMC stage issue, wave completion, approval, or readiness/blocker change. Stale tracker text is a governance defect.
 
 ## Retrofit Notes
 
@@ -26,33 +26,36 @@
 
 | Stage | Name | Status | Notes |
 |-------|------|--------|-------|
-| 1 | App Description | COMPLETE + RETROFIT ADDENDUM PRODUCED | CS2-approved 2026-04-22. Functional-delivery addendum merged in #1186. |
-| 2 | UX Workflow & Wiring Spec | COMPLETE + RETROFIT ADDENDUM PRODUCED | CS2-approved 2026-04-22. CTA/API/Data/Audit matrix merged in #1186. |
-| 3 | FRS | COMPLETE - CS2 APPROVED + RETROFIT ADDENDUM PRODUCED | FR-1900 merged in #1186. |
-| 4 | TRS | TREATED AS APPROVED + RETROFIT ADDENDUM PRODUCED | TR-1900, including TR-1910, merged in #1186. |
-| 5 | Architecture | APPROVAL-PENDING / RETROFIT MERGED AS REFERENCE INPUT | PR #1188 merged retrofit inputs; merge is not Stage 5 approval. |
-| 5a | Deployment Execution Strategy | APPROVAL-PENDING / RETROFIT MERGED AS REFERENCE INPUT | PR #1190 merged retrofit inputs; merge is not Stage 5a approval. |
-| 6 | QA-to-Red | APPROVAL-PENDING / RETROFIT MERGED AS REFERENCE INPUT | PR #1192 merged retrofit inputs; merge is not Stage 6 approval. |
-| **7** | **PBFAG** | **IN PROGRESS - RETROFIT ACTIVE** | PR #1194 imports Stage 5/5a/6 retrofit controls as hard PBFAG gates. |
-| 8 | Implementation Plan | Not Started | BLOCKED until Stages 5, 5a, 6, and 7 are CS2-dispositioned. |
-| 9 | Builder Checklist | Not Started | BLOCKED |
-| 10 | IAA Pre-Brief | Not Started | BLOCKED |
-| 11 | Builder Appointment | Not Started | BLOCKED |
-| 12 | Build | Not Started | BLOCKED |
+| 1 | App Description | ✅ COMPLETE + 🟡 RETROFIT ADDENDUM PRODUCED | CS2-approved 2026-04-22. Functional-delivery addendum merged in #1186. |
+| 2 | UX Workflow & Wiring Spec | ✅ COMPLETE + 🟡 RETROFIT ADDENDUM PRODUCED | CS2-approved 2026-04-22. CTA/API/Data/Audit matrix merged in #1186. |
+| 3 | FRS | ✅ COMPLETE - CS2 APPROVED + 🟡 RETROFIT ADDENDUM PRODUCED | FR-1900 merged in #1186. |
+| 4 | TRS | ✅ TREATED AS APPROVED + 🟡 RETROFIT ADDENDUM PRODUCED | TR-1900, including TR-1910, merged in #1186. |
+| 5 | Architecture | 🟡 IN PROGRESS — Produced Approval-Pending | PR #1188 merged retrofit inputs; merge is not Stage 5 approval. |
+| 5a | Deployment Execution Strategy | 🟡 IN PROGRESS — Produced Approval-Pending | PR #1190 merged retrofit inputs; merge is not Stage 5a approval. |
+| 6 | QA-to-Red | 🟡 IN PROGRESS — Produced Approval-Pending | PR #1192 merged retrofit inputs; merge is not Stage 6 approval. |
+| **7** | **PBFAG** | **🟡 IN PROGRESS — Produced Approval-Pending** | PR #1194 imports Stage 5/5a/6 retrofit controls as hard PBFAG gates. |
+| 8 | Implementation Plan | ⬜ Not Started — 🔴 BLOCKED | Must not start until Stages 5, 5a, 6, and 7 are CS2-dispositioned. |
+| 9 | Builder Checklist | ⬜ Not Started — 🔴 BLOCKED | Blocked until Stage 8 is authorized and complete. |
+| 10 | IAA Pre-Brief | ⬜ Not Started — 🔴 BLOCKED | Blocked until canonical sequence authorizes it. |
+| 11 | Builder Appointment | ⬜ Not Started — 🔴 BLOCKED | No builders appointed. |
+| 12 | Build | ⬜ Not Started — 🔴 BLOCKED | No implementation/build authorization. |
 
 ---
 
 ## Stage 7 - PBFAG
 
-**Status**: IN PROGRESS - RETROFIT ACTIVE  
+**Status**: 🟡 IN PROGRESS — Produced Approval-Pending  
 **Location**: `modules/amc/06-pbfag/`
 
-**Key Artifacts**:
+**Key Artifacts and Hard-Gate Inputs**:
 - [x] `pre-build-final-assurance-gate.md`
 - [x] `pbfag-evidence-matrix.md`
 - [x] `pbfag-findings-and-verdict.md`
 - [x] `pbfag-checklist.md`
 - [x] `stage1-4-functional-delivery-change-propagation-audit.md`
+- [x] `functional-delivery-architecture-map.md` - Stage 5 hard-gate input
+- [x] `deployment-execution-validation-matrix.md` - Stage 5a hard-gate input
+- [x] `functional-delivery-red-test-expansion-matrix.md` - Stage 6 QA-FD / QA-DEPLOY hard-gate input
 - [x] `functional-delivery-pbfag-addendum.md` - produced in issue #1193 / PR #1194
 - [x] `pbfag-retrofit-evidence-matrix.md` - produced in issue #1193 / PR #1194
 - [x] `stage7-functional-delivery-change-propagation-audit.md` - produced in issue #1193 / PR #1194
@@ -63,11 +66,11 @@
 
 ## Blocked Downstream Stages
 
-- Stage 8 Implementation Plan: not started.
-- Stage 9 Builder Checklist: not started.
-- Stage 10 IAA Pre-Brief: not started.
-- Stage 11 Builder Appointment: not started.
-- Stage 12 Build: not started.
+- Stage 8 Implementation Plan: not started and blocked.
+- Stage 9 Builder Checklist: not started and blocked.
+- Stage 10 IAA Pre-Brief: not started and blocked.
+- Stage 11 Builder Appointment: not started and blocked.
+- Stage 12 Build: not started and blocked.
 
 ---
 

--- a/modules/amc/BUILD_PROGRESS_TRACKER.md
+++ b/modules/amc/BUILD_PROGRESS_TRACKER.md
@@ -2,14 +2,14 @@
 
 **Module**: App Management Centre (AMC)  
 **Module Slug**: AMC  
-**Last Updated**: 2026-06-29  
-**Updated By**: foreman-v2-agent (wave: amc-stage6-qa-to-red-retrofit-20260629 - issue #1191; PR #1192; Stage 6 QA-to-Red functional-delivery retrofit artifacts produced for CS2 review. PR #1190 is merged. Stage 7, Stage 8, builder checklist, IAA pre-brief, builder appointment, and implementation remain blocked.)
+**Last Updated**: 2026-06-30  
+**Updated By**: foreman-v2-agent (wave: amc-stage7-pbfag-retrofit-20260630 - issue #1193; Stage 7 PBFAG functional-delivery / deployment-execution / QA retrofit active. PR #1192 is merged. Stage 8, builder checklist, IAA pre-brief, builder appointment, and implementation remain blocked.)
 
 > **Classification**: ACTIVE  
 > **Document Role**: PRIMARY LIVE CONTROL DOCUMENT - This is the designated primary operational monitor for AMC pre-build stage progress. CS2 should use this document as the main live progress dashboard.  
 > **Canon Reference**: `PRE_BUILD_STAGE_MODEL_CANON.md` v1.0.0 plus current ISMS/MMM functional-delivery retrofit lessons  
-> **Current Issue**: [app_management_centre#1191](https://github.com/APGI-cmy/app_management_centre/issues/1191)  
-> **Current PR**: [app_management_centre#1192](https://github.com/APGI-cmy/app_management_centre/pull/1192)  
+> **Current Issue**: [app_management_centre#1193](https://github.com/APGI-cmy/app_management_centre/issues/1193)  
+> **Current PR**: pending Stage 7 PR creation  
 > **Update Rule**: This document MUST be updated immediately after every AMC stage issue, wave completion, approval, or readiness/blocker change. Stale tracker text is a governance defect.
 
 > **GOVERNANCE OVERSIGHT NOTE (issue #1133, 2026-04-26)**: A mandatory deployment execution planning stage exists as Stage 5a between Stage 5 Architecture and Stage 6 QA-to-Red. Architecture/platform topology alone is insufficient. Stage 5a must remain separate and CS2-dispositioned before build execution can be considered.
@@ -18,9 +18,11 @@
 
 > **STAGE 5 RETROFIT NOTE (issue #1187, PR #1188, 2026-06-26)**: Stage 5 Architecture was reviewed against the merged Stage 1-4 retrofit. PR #1188 merged Stage 5 functional-delivery retrofit inputs. Stage 5 remains approval-pending until CS2 disposition of the original architecture plus the retrofit package. This does not start Stage 5a, Stage 6, Stage 8, builder checklist, IAA pre-brief, builder appointment, or implementation.
 
-> **STAGE 5A RETROFIT NOTE (issue #1189, PR #1190, 2026-06-29)**: Stage 5a Deployment Execution Strategy was reviewed against the merged Stage 1-5 functional-delivery controls. PR #1190 merged the Stage 5a functional-delivery deployment execution addendum, deployment execution validation matrix, artifact-index reconciliation, and Stage 5a change-propagation audit. This does not start Stage 7, Stage 8, builder checklist, IAA pre-brief, builder appointment, or implementation.
+> **STAGE 5A RETROFIT NOTE (issue #1189, PR #1190, 2026-06-29)**: Stage 5a Deployment Execution Strategy was reviewed against the merged Stage 1-5 functional-delivery controls. PR #1190 merged the Stage 5a functional-delivery deployment execution addendum, deployment execution validation matrix, artifact-index reconciliation, and Stage 5a change-propagation audit. This does not start Stage 8, builder checklist, IAA pre-brief, builder appointment, or implementation.
 
-> **STAGE 6 RETROFIT NOTE (issue #1191, PR #1192, 2026-06-29)**: Stage 6 QA-to-Red is being reviewed against the merged Stage 1-5a functional-delivery and deployment-execution controls. The wave produced a Stage 6 functional-delivery QA-to-Red addendum, functional-delivery RED test expansion matrix, and Stage 6 change-propagation audit. This does not start Stage 7, Stage 8, builder checklist, IAA pre-brief, builder appointment, or implementation.
+> **STAGE 6 RETROFIT NOTE (issue #1191, PR #1192, 2026-06-30)**: Stage 6 QA-to-Red was reviewed against the merged Stage 1-5a functional-delivery and deployment-execution controls. PR #1192 merged the Stage 6 functional-delivery QA-to-Red addendum, functional-delivery RED test expansion matrix, and Stage 6 change-propagation audit. Stage 6 remains approval-pending / retrofit merged as reference input. This does not start Stage 8, builder checklist, IAA pre-brief, builder appointment, or implementation.
+
+> **STAGE 7 RETROFIT NOTE (issue #1193, 2026-06-30)**: Stage 7 PBFAG is being reviewed against the merged Stage 5 route/action/state/audit/degraded-mode map, Stage 5a deployment-execution validation matrix, and Stage 6 QA-FD / QA-DEPLOY RED families. This does not start Stage 8, builder checklist, IAA pre-brief, builder appointment, or implementation.
 
 ---
 
@@ -42,8 +44,8 @@
 | 1-4 Retrofit | Functional Delivery Retrofit | MERGED / REFERENCE INPUT | PR #1186 merged. Stage 5/5a/6/7 must import or disposition its obligations. |
 | 5 | Architecture | APPROVAL-PENDING / RETROFIT MERGED AS REFERENCE INPUT | Original Stage 5 Architecture remains approval-pending. PR #1188 merged retrofit inputs for CS2 disposition; merge is not Stage 5 approval. |
 | 5a | Deployment Execution Strategy | APPROVAL-PENDING / RETROFIT MERGED AS REFERENCE INPUT | Original Stage 5a DES pack remains approval-pending. PR #1190 merged retrofit inputs for CS2 disposition; merge is not Stage 5a approval. |
-| 6 | QA-to-Red | IN PROGRESS - RETROFIT PRODUCED FOR CS2 REVIEW | Existing Stage 6 QA pack remains produced approval-pending. PR #1192 adds Stage 6 functional-delivery addendum, RED expansion matrix, and change-propagation audit. |
-| 7 | PBFAG | PRODUCED APPROVAL-PENDING / NOT STARTED BY #1192 | Stage 7 must later import Stage 5/5a/6 retrofit as hard functional-delivery, deployment-execution, and QA gates. |
+| 6 | QA-to-Red | APPROVAL-PENDING / RETROFIT MERGED AS REFERENCE INPUT | Original Stage 6 QA pack remains approval-pending. PR #1192 merged retrofit inputs for CS2 disposition; merge is not Stage 6 approval. |
+| **7** | **PBFAG** | **IN PROGRESS - RETROFIT ACTIVE** | Existing Stage 7 PBFAG pack remains produced approval-pending. Issue #1193 imports Stage 5/5a/6 retrofit controls as hard PBFAG gates. |
 | 8 | Implementation Plan | Not Started | BLOCKED - must not start until Stages 5, 5a, 6, 7 and retrofit obligations are CS2-dispositioned/imported. |
 | 9 | Builder Checklist | Not Started | BLOCKED |
 | 10 | IAA Pre-Brief | Not Started | BLOCKED |
@@ -72,25 +74,25 @@
 
 ### Stage 6 - QA-to-Red
 
-**Status**: IN PROGRESS - RETROFIT PRODUCED FOR CS2 REVIEW  
+**Status**: APPROVAL-PENDING - RETROFIT MERGED AS REFERENCE INPUT  
 **Location**: `modules/amc/05-qa-to-red/`  
-**Key Artifacts**:
-- [x] `qa-to-red-specification.md`
-- [x] `architecture-and-des-to-qa-traceability.md`
-- [x] `red-test-catalog.md`
-- [x] `functional-delivery-qa-to-red-addendum.md` - produced in issue #1191 / PR #1192
-- [x] `functional-delivery-red-test-expansion-matrix.md` - produced in issue #1191 / PR #1192
-- [x] `stage6-functional-delivery-change-propagation-audit.md` - produced in issue #1191 / PR #1192
-
-**Current gate note**: Stage 6 can only be dispositioned after CS2 reviews the existing Stage 6 QA pack together with the Stage 6 retrofit addendum, RED expansion matrix, artifact-index reconciliation, and change-propagation audit. This tracker update does not approve Stage 6.
+**Current gate note**: Stage 6 is a merged reference input for Stage 7 propagation, but it is not marked CS2-approved by tracker. Stage 6 still requires CS2 disposition of the original QA pack together with the retrofit package. This does not authorize implementation.
 
 ---
 
 ### Stage 7 - PBFAG
 
-**Status**: PRODUCED APPROVAL-PENDING; not started by #1192  
+**Status**: IN PROGRESS - RETROFIT ACTIVE  
 **Location**: `modules/amc/06-pbfag/`  
-**Current gate note**: Stage 7 must later import Stage 5/5a/6 retrofit and fail/condition Stage 8 if material action coverage, deployment execution, route/event authority, evidence package, QA coverage, or placeholder controls remain unresolved.
+**Key Artifacts**:
+- [x] `pre-build-final-assurance-gate.md`
+- [x] `pbfag-evidence-matrix.md`
+- [x] `pbfag-findings-and-verdict.md`
+- [x] `pbfag-checklist.md`
+- [x] `stage1-4-functional-delivery-change-propagation-audit.md`
+- [ ] Stage 7 retrofit addendum / matrix / audit - issue #1193
+
+**Current gate note**: Stage 7 must import Stage 5/5a/6 retrofit obligations and fail/condition Stage 8 if material action coverage, deployment execution, route/event authority, evidence package, QA coverage, or placeholder controls remain unresolved. This tracker update does not approve Stage 7.
 
 ---
 
@@ -98,7 +100,7 @@
 
 **Status**: Not Started  
 **Location**: `modules/amc/07-implementation-plan/`  
-**Current blocker**: Stage 8 remains blocked. PR #1192 does not start Stage 8.
+**Current blocker**: Stage 8 remains blocked. Issue #1193 does not start Stage 8.
 
 ---
 
@@ -130,15 +132,15 @@
 
 **Status**: Not Started  
 **Location**: `modules/amc/11-build/`  
-**Current blocker**: Build remains blocked. PR #1192 does not authorize implementation.
+**Current blocker**: Build remains blocked. Issue #1193 does not authorize implementation.
 
 ---
 
 ## Next Action
 
-1. Review PR #1192 for Stage 6 QA-to-Red functional-delivery alignment.
-2. CS2 to disposition whether the existing Stage 6 QA-to-Red pack may be approved with the Stage 6 addendum, RED expansion matrix, artifact-index reconciliation, and audit attached.
-3. Do not start Stage 7 or Stage 8 from this PR.
+1. Complete issue #1193 Stage 7 PBFAG retrofit package.
+2. CS2 to disposition whether the existing Stage 7 PBFAG pack may be approved with Stage 5, Stage 5a, and Stage 6 retrofit obligations attached.
+3. Do not start Stage 8 from this wave.
 4. Do not appoint builders until the canonical pre-build sequence authorizes Stage 11.
 
 ---
@@ -158,10 +160,10 @@
 - [functional-delivery-deployment-execution-addendum.md](./05a-deployment-execution-strategy/functional-delivery-deployment-execution-addendum.md)
 - [deployment-execution-validation-matrix.md](./05a-deployment-execution-strategy/deployment-execution-validation-matrix.md)
 - [stage5a-functional-delivery-change-propagation-audit.md](./05a-deployment-execution-strategy/stage5a-functional-delivery-change-propagation-audit.md)
-- [qa-to-red-specification.md](./05-qa-to-red/qa-to-red-specification.md)
-- [architecture-and-des-to-qa-traceability.md](./05-qa-to-red/architecture-and-des-to-qa-traceability.md)
-- [red-test-catalog.md](./05-qa-to-red/red-test-catalog.md)
 - [functional-delivery-qa-to-red-addendum.md](./05-qa-to-red/functional-delivery-qa-to-red-addendum.md)
 - [functional-delivery-red-test-expansion-matrix.md](./05-qa-to-red/functional-delivery-red-test-expansion-matrix.md)
 - [stage6-functional-delivery-change-propagation-audit.md](./05-qa-to-red/stage6-functional-delivery-change-propagation-audit.md)
+- [pre-build-final-assurance-gate.md](./06-pbfag/pre-build-final-assurance-gate.md)
+- [pbfag-evidence-matrix.md](./06-pbfag/pbfag-evidence-matrix.md)
+- [pbfag-findings-and-verdict.md](./06-pbfag/pbfag-findings-and-verdict.md)
 - [AMC_PRE_BUILD_ARTIFACT_INDEX.md](./AMC_PRE_BUILD_ARTIFACT_INDEX.md)

--- a/modules/amc/BUILD_PROGRESS_TRACKER.md
+++ b/modules/amc/BUILD_PROGRESS_TRACKER.md
@@ -3,33 +3,22 @@
 **Module**: App Management Centre (AMC)  
 **Module Slug**: AMC  
 **Last Updated**: 2026-06-30  
-**Updated By**: foreman-v2-agent (wave: amc-stage7-pbfag-retrofit-20260630 - issue #1193; Stage 7 PBFAG functional-delivery / deployment-execution / QA retrofit active. PR #1192 is merged. Stage 8, builder checklist, IAA pre-brief, builder appointment, and implementation remain blocked.)
+**Updated By**: foreman-v2-agent (wave: amc-stage7-pbfag-retrofit-20260630 - issue #1193; PR #1194; Stage 7 PBFAG retrofit active. PR #1192 is merged. Stage 8 and all build-readiness stages remain blocked.)
 
 > **Classification**: ACTIVE  
-> **Document Role**: PRIMARY LIVE CONTROL DOCUMENT - This is the designated primary operational monitor for AMC pre-build stage progress. CS2 should use this document as the main live progress dashboard.  
+> **Document Role**: PRIMARY LIVE CONTROL DOCUMENT - CS2 should use this document as the main live progress dashboard.  
 > **Canon Reference**: `PRE_BUILD_STAGE_MODEL_CANON.md` v1.0.0 plus current ISMS/MMM functional-delivery retrofit lessons  
 > **Current Issue**: [app_management_centre#1193](https://github.com/APGI-cmy/app_management_centre/issues/1193)  
-> **Current PR**: pending Stage 7 PR creation  
-> **Update Rule**: This document MUST be updated immediately after every AMC stage issue, wave completion, approval, or readiness/blocker change. Stale tracker text is a governance defect.
+> **Current PR**: [app_management_centre#1194](https://github.com/APGI-cmy/app_management_centre/pull/1194)  
+> **Update Rule**: This document MUST be updated after every AMC stage issue, wave completion, approval, or readiness/blocker change.
 
-> **GOVERNANCE OVERSIGHT NOTE (issue #1133, 2026-04-26)**: A mandatory deployment execution planning stage exists as Stage 5a between Stage 5 Architecture and Stage 6 QA-to-Red. Architecture/platform topology alone is insufficient. Stage 5a must remain separate and CS2-dispositioned before build execution can be considered.
+## Retrofit Notes
 
-> **FUNCTIONAL DELIVERY RETROFIT NOTE (issue #1185, PR #1186, 2026-06-25)**: AMC Stages 1-4 were retrofitted with Stage 1 functional-delivery definition, Stage 2 CTA/API/Data/Audit matrix, Stage 3 FR-1900, Stage 4 TR-1900, and a Stage 1-4 change-propagation audit. Stages 5, 5a, 6, and 7 must import or explicitly disposition those obligations before Stage 8 may begin.
-
-> **STAGE 5 RETROFIT NOTE (issue #1187, PR #1188, 2026-06-26)**: Stage 5 Architecture was reviewed against the merged Stage 1-4 retrofit. PR #1188 merged Stage 5 functional-delivery retrofit inputs. Stage 5 remains approval-pending until CS2 disposition of the original architecture plus the retrofit package. This does not start Stage 5a, Stage 6, Stage 8, builder checklist, IAA pre-brief, builder appointment, or implementation.
-
-> **STAGE 5A RETROFIT NOTE (issue #1189, PR #1190, 2026-06-29)**: Stage 5a Deployment Execution Strategy was reviewed against the merged Stage 1-5 functional-delivery controls. PR #1190 merged the Stage 5a functional-delivery deployment execution addendum, deployment execution validation matrix, artifact-index reconciliation, and Stage 5a change-propagation audit. This does not start Stage 8, builder checklist, IAA pre-brief, builder appointment, or implementation.
-
-> **STAGE 6 RETROFIT NOTE (issue #1191, PR #1192, 2026-06-30)**: Stage 6 QA-to-Red was reviewed against the merged Stage 1-5a functional-delivery and deployment-execution controls. PR #1192 merged the Stage 6 functional-delivery QA-to-Red addendum, functional-delivery RED test expansion matrix, and Stage 6 change-propagation audit. Stage 6 remains approval-pending / retrofit merged as reference input. This does not start Stage 8, builder checklist, IAA pre-brief, builder appointment, or implementation.
-
-> **STAGE 7 RETROFIT NOTE (issue #1193, 2026-06-30)**: Stage 7 PBFAG is being reviewed against the merged Stage 5 route/action/state/audit/degraded-mode map, Stage 5a deployment-execution validation matrix, and Stage 6 QA-FD / QA-DEPLOY RED families. This does not start Stage 8, builder checklist, IAA pre-brief, builder appointment, or implementation.
-
----
-
-## Lifecycle Model
-
-**Canonical 12-Stage Pre-Build Sequence** (`PRE_BUILD_STAGE_MODEL_CANON.md` v1.0.0)  
-**Tracker Authority**: Repo-local - tracks AMC-specific stage completion within this repository
+- PR #1186 merged Stage 1-4 functional-delivery reference inputs.
+- PR #1188 merged Stage 5 architecture retrofit reference inputs. Stage 5 remains approval-pending.
+- PR #1190 merged Stage 5a deployment-execution retrofit reference inputs. Stage 5a remains approval-pending.
+- PR #1192 merged Stage 6 QA-to-Red retrofit reference inputs. Stage 6 remains approval-pending.
+- Issue #1193 / PR #1194 imports Stage 5 route/action/state/audit/degraded-mode obligations, Stage 5a deployment-execution obligations, and Stage 6 QA-FD / QA-DEPLOY obligations into Stage 7 PBFAG.
 
 ---
 
@@ -38,109 +27,55 @@
 | Stage | Name | Status | Notes |
 |-------|------|--------|-------|
 | 1 | App Description | COMPLETE + RETROFIT ADDENDUM PRODUCED | CS2-approved 2026-04-22. Functional-delivery addendum merged in #1186. |
-| 2 | UX Workflow & Wiring Spec | COMPLETE + RETROFIT ADDENDUM PRODUCED | CS2-approved 2026-04-22. CTA/API/Data/Audit matrix merged in #1186 and remains canonicalization-bound to TRS route/event contracts. |
+| 2 | UX Workflow & Wiring Spec | COMPLETE + RETROFIT ADDENDUM PRODUCED | CS2-approved 2026-04-22. CTA/API/Data/Audit matrix merged in #1186. |
 | 3 | FRS | COMPLETE - CS2 APPROVED + RETROFIT ADDENDUM PRODUCED | FR-1900 merged in #1186. |
 | 4 | TRS | TREATED AS APPROVED + RETROFIT ADDENDUM PRODUCED | TR-1900, including TR-1910, merged in #1186. |
-| 1-4 Retrofit | Functional Delivery Retrofit | MERGED / REFERENCE INPUT | PR #1186 merged. Stage 5/5a/6/7 must import or disposition its obligations. |
-| 5 | Architecture | APPROVAL-PENDING / RETROFIT MERGED AS REFERENCE INPUT | Original Stage 5 Architecture remains approval-pending. PR #1188 merged retrofit inputs for CS2 disposition; merge is not Stage 5 approval. |
-| 5a | Deployment Execution Strategy | APPROVAL-PENDING / RETROFIT MERGED AS REFERENCE INPUT | Original Stage 5a DES pack remains approval-pending. PR #1190 merged retrofit inputs for CS2 disposition; merge is not Stage 5a approval. |
-| 6 | QA-to-Red | APPROVAL-PENDING / RETROFIT MERGED AS REFERENCE INPUT | Original Stage 6 QA pack remains approval-pending. PR #1192 merged retrofit inputs for CS2 disposition; merge is not Stage 6 approval. |
-| **7** | **PBFAG** | **IN PROGRESS - RETROFIT ACTIVE** | Existing Stage 7 PBFAG pack remains produced approval-pending. Issue #1193 imports Stage 5/5a/6 retrofit controls as hard PBFAG gates. |
-| 8 | Implementation Plan | Not Started | BLOCKED - must not start until Stages 5, 5a, 6, 7 and retrofit obligations are CS2-dispositioned/imported. |
+| 5 | Architecture | APPROVAL-PENDING / RETROFIT MERGED AS REFERENCE INPUT | PR #1188 merged retrofit inputs; merge is not Stage 5 approval. |
+| 5a | Deployment Execution Strategy | APPROVAL-PENDING / RETROFIT MERGED AS REFERENCE INPUT | PR #1190 merged retrofit inputs; merge is not Stage 5a approval. |
+| 6 | QA-to-Red | APPROVAL-PENDING / RETROFIT MERGED AS REFERENCE INPUT | PR #1192 merged retrofit inputs; merge is not Stage 6 approval. |
+| **7** | **PBFAG** | **IN PROGRESS - RETROFIT ACTIVE** | PR #1194 imports Stage 5/5a/6 retrofit controls as hard PBFAG gates. |
+| 8 | Implementation Plan | Not Started | BLOCKED until Stages 5, 5a, 6, and 7 are CS2-dispositioned. |
 | 9 | Builder Checklist | Not Started | BLOCKED |
 | 10 | IAA Pre-Brief | Not Started | BLOCKED |
-| 11 | Builder Appointment | Not Started | BLOCKED - no builders appointed. |
-| 12 | Build | Not Started | BLOCKED - no implementation/build authorization. |
+| 11 | Builder Appointment | Not Started | BLOCKED |
+| 12 | Build | Not Started | BLOCKED |
 
 ---
 
-## Stage Detail
-
-### Stage 5 - Architecture
-
-**Status**: APPROVAL-PENDING - RETROFIT MERGED AS REFERENCE INPUT  
-**Location**: `modules/amc/04-architecture/`  
-**Current gate note**: Stage 5 is a merged reference input for Stage 5a/6/7 propagation, but it is not marked CS2-approved by tracker. Stage 5 still requires CS2 disposition of the original architecture together with the retrofit package. This does not authorize implementation.
-
----
-
-### Stage 5a - Deployment Execution Strategy
-
-**Status**: APPROVAL-PENDING - RETROFIT MERGED AS REFERENCE INPUT  
-**Location**: `modules/amc/05a-deployment-execution-strategy/`  
-**Current gate note**: Stage 5a is a merged reference input for Stage 6/7 propagation, but it is not marked CS2-approved by tracker. Stage 5a still requires CS2 disposition of the original DES pack together with the retrofit package. This does not authorize implementation.
-
----
-
-### Stage 6 - QA-to-Red
-
-**Status**: APPROVAL-PENDING - RETROFIT MERGED AS REFERENCE INPUT  
-**Location**: `modules/amc/05-qa-to-red/`  
-**Current gate note**: Stage 6 is a merged reference input for Stage 7 propagation, but it is not marked CS2-approved by tracker. Stage 6 still requires CS2 disposition of the original QA pack together with the retrofit package. This does not authorize implementation.
-
----
-
-### Stage 7 - PBFAG
+## Stage 7 - PBFAG
 
 **Status**: IN PROGRESS - RETROFIT ACTIVE  
-**Location**: `modules/amc/06-pbfag/`  
+**Location**: `modules/amc/06-pbfag/`
+
 **Key Artifacts**:
 - [x] `pre-build-final-assurance-gate.md`
 - [x] `pbfag-evidence-matrix.md`
 - [x] `pbfag-findings-and-verdict.md`
 - [x] `pbfag-checklist.md`
 - [x] `stage1-4-functional-delivery-change-propagation-audit.md`
-- [ ] Stage 7 retrofit addendum / matrix / audit - issue #1193
+- [x] `functional-delivery-pbfag-addendum.md` - produced in issue #1193 / PR #1194
+- [x] `pbfag-retrofit-evidence-matrix.md` - produced in issue #1193 / PR #1194
+- [x] `stage7-functional-delivery-change-propagation-audit.md` - produced in issue #1193 / PR #1194
 
-**Current gate note**: Stage 7 must import Stage 5/5a/6 retrofit obligations and fail/condition Stage 8 if material action coverage, deployment execution, route/event authority, evidence package, QA coverage, or placeholder controls remain unresolved. This tracker update does not approve Stage 7.
-
----
-
-### Stage 8 - Implementation Plan
-
-**Status**: Not Started  
-**Location**: `modules/amc/07-implementation-plan/`  
-**Current blocker**: Stage 8 remains blocked. Issue #1193 does not start Stage 8.
+**Current gate note**: Stage 7 must import Stage 5/5a/6 retrofit obligations and fail or condition Stage 8 if material action coverage, deployment execution, route/event authority, evidence package, QA coverage, or placeholder controls remain unresolved. This tracker update does not approve Stage 7.
 
 ---
 
-### Stage 9 - Builder Checklist
+## Blocked Downstream Stages
 
-**Status**: Not Started  
-**Location**: `modules/amc/08-builder-checklist/`  
-**Current blocker**: Stage 9 remains blocked because Stage 8 has not started.
-
----
-
-### Stage 10 - IAA Pre-Brief
-
-**Status**: Not Started  
-**Location**: `modules/amc/09-iaa-pre-brief/`  
-**Current blocker**: Stage 10 remains blocked because Stage 9 has not started.
-
----
-
-### Stage 11 - Builder Appointment
-
-**Status**: Not Started  
-**Location**: `modules/amc/10-builder-appointment/`  
-**Current blocker**: No builders appointed. Stage 11 remains blocked.
-
----
-
-### Stage 12 - Build
-
-**Status**: Not Started  
-**Location**: `modules/amc/11-build/`  
-**Current blocker**: Build remains blocked. Issue #1193 does not authorize implementation.
+- Stage 8 Implementation Plan: not started.
+- Stage 9 Builder Checklist: not started.
+- Stage 10 IAA Pre-Brief: not started.
+- Stage 11 Builder Appointment: not started.
+- Stage 12 Build: not started.
 
 ---
 
 ## Next Action
 
-1. Complete issue #1193 Stage 7 PBFAG retrofit package.
+1. Review PR #1194 for Stage 7 PBFAG functional-delivery / deployment-execution / QA alignment.
 2. CS2 to disposition whether the existing Stage 7 PBFAG pack may be approved with Stage 5, Stage 5a, and Stage 6 retrofit obligations attached.
-3. Do not start Stage 8 from this wave.
+3. Do not start Stage 8 from this PR.
 4. Do not appoint builders until the canonical pre-build sequence authorizes Stage 11.
 
 ---
@@ -148,22 +83,13 @@
 ## References
 
 - [PRE_BUILD_STAGE_MODEL_CANON.md](../../governance/canon/PRE_BUILD_STAGE_MODEL_CANON.md)
-- [architecture-specification.md](./04-architecture/architecture-specification.md)
-- [functional-delivery-definition.md](./00-app-description/functional-delivery-definition.md)
-- [cta-api-data-audit-contract-matrix.md](./01-ux-workflow-wiring-spec/cta-api-data-audit-contract-matrix.md)
-- [functional-delivery-requirements-addendum.md](./02-frs/functional-delivery-requirements-addendum.md)
-- [functional-delivery-technical-requirements-addendum.md](./03-trs/functional-delivery-technical-requirements-addendum.md)
-- [stage1-4-functional-delivery-change-propagation-audit.md](./06-pbfag/stage1-4-functional-delivery-change-propagation-audit.md)
-- [functional-delivery-architecture-addendum.md](./04-architecture/functional-delivery-architecture-addendum.md)
 - [functional-delivery-architecture-map.md](./04-architecture/functional-delivery-architecture-map.md)
-- [stage5-functional-delivery-change-propagation-audit.md](./04-architecture/stage5-functional-delivery-change-propagation-audit.md)
-- [functional-delivery-deployment-execution-addendum.md](./05a-deployment-execution-strategy/functional-delivery-deployment-execution-addendum.md)
 - [deployment-execution-validation-matrix.md](./05a-deployment-execution-strategy/deployment-execution-validation-matrix.md)
-- [stage5a-functional-delivery-change-propagation-audit.md](./05a-deployment-execution-strategy/stage5a-functional-delivery-change-propagation-audit.md)
-- [functional-delivery-qa-to-red-addendum.md](./05-qa-to-red/functional-delivery-qa-to-red-addendum.md)
 - [functional-delivery-red-test-expansion-matrix.md](./05-qa-to-red/functional-delivery-red-test-expansion-matrix.md)
-- [stage6-functional-delivery-change-propagation-audit.md](./05-qa-to-red/stage6-functional-delivery-change-propagation-audit.md)
 - [pre-build-final-assurance-gate.md](./06-pbfag/pre-build-final-assurance-gate.md)
 - [pbfag-evidence-matrix.md](./06-pbfag/pbfag-evidence-matrix.md)
 - [pbfag-findings-and-verdict.md](./06-pbfag/pbfag-findings-and-verdict.md)
+- [functional-delivery-pbfag-addendum.md](./06-pbfag/functional-delivery-pbfag-addendum.md)
+- [pbfag-retrofit-evidence-matrix.md](./06-pbfag/pbfag-retrofit-evidence-matrix.md)
+- [stage7-functional-delivery-change-propagation-audit.md](./06-pbfag/stage7-functional-delivery-change-propagation-audit.md)
 - [AMC_PRE_BUILD_ARTIFACT_INDEX.md](./AMC_PRE_BUILD_ARTIFACT_INDEX.md)


### PR DESCRIPTION
## Summary

governing_issue: #1193

This PR opens the AMC Stage 7 PBFAG Functional Delivery / Deployment Execution / QA Retrofit wave requested in issue #1193.

It reviews the existing Stage 7 PBFAG pack against the merged Stage 1-4 functional-delivery retrofit from PR #1186, the merged Stage 5 Architecture retrofit from PR #1188, the merged Stage 5a Deployment Execution retrofit from PR #1190, and the merged Stage 6 QA-to-Red retrofit from PR #1192.

## Added / updated artifacts

1. `modules/amc/06-pbfag/functional-delivery-pbfag-addendum.md`
   - Imports Stage 5 route/action/state/audit/degraded-mode obligations, Stage 5a deployment-execution obligations, and Stage 6 QA-FD / QA-DEPLOY obligations into Stage 7 PBFAG.

2. `modules/amc/06-pbfag/pbfag-retrofit-evidence-matrix.md`
   - Adds PBFAG-FD, PBFAG-DEPLOY, PBFAG-QA, tracker, and Stage 8 block evidence rows.

3. `modules/amc/06-pbfag/stage7-functional-delivery-change-propagation-audit.md`
   - Records the Stage 7 retrofit findings and downstream carry-forward requirements.

4. `modules/amc/BUILD_PROGRESS_TRACKER.md`
   - Updates the live tracker first to record PR #1192 merged, Stage 6 as approval-pending / retrofit reference input, and Stage 7 as active.

5. `modules/amc/AMC_PRE_BUILD_ARTIFACT_INDEX.md`
   - Reconciles the artifact index with the Stage 7 retrofit artifacts while preserving later-stage placeholders.

6. `.agent-admin/wave-records/amc-wave-record-1193-current.md`
   - Records the Stage 7 retrofit wave without invoking any Stage 8/build/handover authority.

## Governance constraints

- Does not approve Stage 7.
- Does not approve Stage 5, Stage 5a, or Stage 6.
- Does not start Stage 8.
- Does not create the Stage 8 implementation plan.
- Does not create builder checklist.
- Does not create IAA pre-brief.
- Does not appoint builders.
- Does not authorize implementation work.
- Does not certify AMC build-readiness.

## Key findings

- Existing Stage 7 PBFAG pack is structurally strong and not rejected.
- Existing Stage 7 predates the merged Stage 5/5a/6 retrofit chain and therefore needed explicit import/disposition controls.
- The retrofit adds hard-gate coverage for material route/action closure, deployment execution validation, Stage 6 QA-FD and QA-DEPLOY families, first E2E `/alerts` acknowledgement evidence, placeholder/stub rejection, tracker/index agreement, and Stage 8 block preservation.

## Review focus

Please review whether the Stage 7 package now gives CS2 enough PBFAG clarity to prevent Stage 8 from starting while functional-delivery closure, deployment-execution evidence, QA-FD/QA-DEPLOY coverage, first E2E evidence, or placeholder controls remain unresolved.

Closes #1193 only after CS2 disposition and tracker/artifact-index reconciliation are completed; this PR currently produces the Stage 7 retrofit artifacts for review.