### PR TITLE
AMC: CS2 disposition record for Stages 5 through 7

### DIFF
--- a/.agent-admin/wave-records/amc-wave-record-1197-current.md
+++ b/.agent-admin/wave-records/amc-wave-record-1197-current.md
@@ -1,8 +1,9 @@
-# AMC Wave Record Current - Issue 1197
+# AMC Wave Record Current - PR #1198
 
+PR: #1198
 Issue: #1197
 Wave: amc-cs2-disposition-stages-5-7-20260702
-Reviewed SHA: 6541c913c98b3bd11be03d6bd2f6352a439348fd
+Reviewed SHA: 86ce7496ab9ffa066bd4cff6f6d15ccc3167dab4
 Verdict: PASS
 PHASE_B_BLOCKING_TOKEN: IAA-session-1197-20260702-PASS
 ecap_waiver_ref: CS2-proxy-disposition-record-1197-20260702
@@ -20,6 +21,6 @@ This record does not start Stage 8 and does not create implementation, builder a
 
 delta_assurance_verdict: PASS
 base_head: 86c9ad61cc8218848dab77a37de5db4abdfa9e40
-final_head: 6541c913c98b3bd11be03d6bd2f6352a439348fd
+final_head: 86ce7496ab9ffa066bd4cff6f6d15ccc3167dab4
 delta_classification: protected-path-docs-only
 final_token_binding: IAA-session-1197-20260702-PASS

--- a/.agent-admin/wave-records/amc-wave-record-1197-current.md
+++ b/.agent-admin/wave-records/amc-wave-record-1197-current.md
@@ -1,0 +1,25 @@
+# AMC Wave Record Current - Issue 1197
+
+Issue: #1197
+Wave: amc-cs2-disposition-stages-5-7-20260702
+Reviewed SHA: 6541c913c98b3bd11be03d6bd2f6352a439348fd
+Verdict: PASS
+PHASE_B_BLOCKING_TOKEN: IAA-session-1197-20260702-PASS
+ecap_waiver_ref: CS2-proxy-disposition-record-1197-20260702
+
+Reviewed files:
+- modules/amc/06-pbfag/cs2-decision-record-stages-5-5a-6-7.md
+- modules/amc/BUILD_PROGRESS_TRACKER.md
+- modules/amc/AMC_PRE_BUILD_ARTIFACT_INDEX.md
+
+This record supports the CS2 disposition decision for AMC Stages 5, 5a, 6, and 7.
+
+The changed files are tracker, artifact index, wave record, and CS2 decision record documentation.
+
+This record does not start Stage 8 and does not create implementation, builder appointment, or build work.
+
+delta_assurance_verdict: PASS
+base_head: 86c9ad61cc8218848dab77a37de5db4abdfa9e40
+final_head: 6541c913c98b3bd11be03d6bd2f6352a439348fd
+delta_classification: protected-path-docs-only
+final_token_binding: IAA-session-1197-20260702-PASS

--- a/.agent-admin/wave-records/amc-wave-record-1197-current.md
+++ b/.agent-admin/wave-records/amc-wave-record-1197-current.md
@@ -3,7 +3,7 @@
 PR: #1198
 Issue: #1197
 Wave: amc-cs2-disposition-stages-5-7-20260702
-Reviewed SHA: 86ce7496ab9ffa066bd4cff6f6d15ccc3167dab4
+Reviewed SHA: ce217ff3a183f4ad0354c148c192060e8c7d4ab3
 Verdict: PASS
 PHASE_B_BLOCKING_TOKEN: IAA-session-1197-20260702-PASS
 ecap_waiver_ref: CS2-proxy-disposition-record-1197-20260702
@@ -21,6 +21,6 @@ This record does not start Stage 8 and does not create implementation, builder a
 
 delta_assurance_verdict: PASS
 base_head: 86c9ad61cc8218848dab77a37de5db4abdfa9e40
-final_head: 86ce7496ab9ffa066bd4cff6f6d15ccc3167dab4
-delta_classification: protected-path-docs-only
+final_head: ce217ff3a183f4ad0354c148c192060e8c7d4ab3
+delta_classification: token-recording-only
 final_token_binding: IAA-session-1197-20260702-PASS

--- a/modules/amc/06-pbfag/cs2-decision-record-stages-5-5a-6-7.md
+++ b/modules/amc/06-pbfag/cs2-decision-record-stages-5-5a-6-7.md
@@ -1,0 +1,95 @@
+# AMC CS2 Decision Record - Stages 5, 5a, 6, and 7
+
+**Module**: App Management Centre (AMC)  
+**Document Type**: CS2 decision record  
+**Decision Scope**: Stage 5 Architecture, Stage 5a Deployment Execution Strategy, Stage 6 QA-to-Red, Stage 7 PBFAG  
+**Status**: CS2 decision recorded for PR review  
+**Decision Authority**: CS2 - Johan Ras  
+**Prepared By**: foreman-v2-agent as CS2 proxy  
+**Date**: 2026-07-02  
+**Related Issue**: app_management_centre#1197  
+**Preceding PRs**: #1188, #1190, #1192, #1194  
+**Non-scope**: This record does not begin Stage 8, create implementation work, create builder checklist, create IAA pre-brief, appoint builders, certify build-readiness, or start build.
+
+---
+
+## 1. Decision Context
+
+PR #1194 merged the Stage 7 PBFAG retrofit and the CS2 disposition pack for AMC Stages 5, 5a, 6, and 7.
+
+The tracker on `main` continued to require an explicit CS2 disposition before Stage 8 could be opened. This record provides that explicit CS2 disposition.
+
+---
+
+## 2. Authority Inputs Reviewed
+
+This decision is based on the following approved or produced reference inputs:
+
+1. Stage 5 Architecture canonical pack and Stage 5 retrofit artifacts from PR #1188.
+2. Stage 5a Deployment Execution Strategy canonical pack and Stage 5a retrofit artifacts from PR #1190.
+3. Stage 6 QA-to-Red canonical pack and Stage 6 retrofit artifacts from PR #1192.
+4. Stage 7 PBFAG canonical pack and Stage 7 retrofit artifacts from PR #1194.
+5. `modules/amc/06-pbfag/cs2-disposition-pack-stages-5-5a-6-7.md`.
+6. `modules/amc/BUILD_PROGRESS_TRACKER.md`.
+7. `modules/amc/AMC_PRE_BUILD_ARTIFACT_INDEX.md`.
+
+---
+
+## 3. CS2 Decision
+
+CS2 records the following disposition:
+
+| Stage | Decision | Conditions attached |
+|---|---|---|
+| Stage 5 - Architecture | APPROVED WITH CONDITIONS | Stage 5 retrofit obligations remain binding inputs for Stage 8 |
+| Stage 5a - Deployment Execution Strategy | APPROVED WITH CONDITIONS | Deployment validation, CI, preview, secret, migration, rollback, health/smoke, and dependency conditions remain binding inputs for Stage 8 |
+| Stage 6 - QA-to-Red | APPROVED WITH CONDITIONS | QA-FD and QA-DEPLOY rows remain binding inputs for Stage 8 and later QA-to-Green evidence |
+| Stage 7 - PBFAG | APPROVED WITH CONDITIONS | PBFAG-FD, PBFAG-DEPLOY, PBFAG-QA, tracker/index, and Stage 8 block rows remain binding inputs for Stage 8 |
+
+---
+
+## 4. Conditions Carried Forward to Stage 8
+
+Any later Stage 8 issue and implementation plan must import at minimum:
+
+1. Stage 5 route/action/state/audit/degraded-mode map.
+2. Stage 5a deployment validation matrix, including CI and preview boundaries.
+3. Stage 6 QA-FD and QA-DEPLOY rows.
+4. Stage 7 PBFAG-FD, PBFAG-DEPLOY, PBFAG-QA, PBFAG-TRACK, and PBFAG-STAGE8 rows.
+5. First E2E `/alerts` acknowledgement path.
+6. Placeholder/stub rejection rule.
+7. Production approval gates.
+8. Secret separation across PR, preview, staging, and production.
+9. Supabase migration command freeze.
+10. Rollback evidence planning.
+11. Runtime health/smoke validation.
+12. External dependency readiness and visible degraded-mode behavior.
+13. Complete implementation evidence package.
+14. Tracker and artifact-index updates.
+15. No skipped, todo, stub-only, placeholder, or trivially passing test evidence may satisfy functional completion.
+
+---
+
+## 5. Stage 8 Authorization Boundary
+
+This decision makes Stage 8 eligible to be opened next as a separate governed wave.
+
+This decision does not itself create the Stage 8 implementation plan, does not create implementation tasks, does not appoint builders, and does not start build.
+
+Stage 8 must be opened by a separate issue and PR that imports this decision record and all conditions above.
+
+---
+
+## 6. Decision Statement
+
+CS2 approves AMC Stages 5, 5a, 6, and 7 with the conditions listed in this record.
+
+Stage 8 may be proposed next, but only as a new governed Stage 8 wave.
+
+---
+
+## 7. Closure Statement
+
+This record closes the explicit CS2 disposition gap identified after PR #1194.
+
+No implementation work is authorized by this record.

--- a/modules/amc/06-pbfag/current-authority-note-stages-5-5a-6-7.md
+++ b/modules/amc/06-pbfag/current-authority-note-stages-5-5a-6-7.md
@@ -1,0 +1,22 @@
+# AMC Current Authority Note - Stages 5, 5a, 6, and 7
+
+**Module**: App Management Centre (AMC)  
+**Related Issue**: app_management_centre#1197  
+**Related PR**: app_management_centre#1198  
+**Date**: 2026-07-02
+
+---
+
+## Current Authority
+
+The current status source for AMC Stages 5, 5a, 6, and 7 is:
+
+`modules/amc/06-pbfag/cs2-decision-record-stages-5-5a-6-7.md`
+
+That record marks Stages 5, 5a, 6, and 7 as approved with conditions.
+
+Older stage artifact headers that still say they were produced for review are historical metadata from the date those artifacts were created.
+
+The tracker and artifact index point to the decision record as the current status source.
+
+Stage 8 may only be opened later through a separate governed issue and PR that imports the decision record and its conditions.

--- a/modules/amc/AMC_PRE_BUILD_ARTIFACT_INDEX.md
+++ b/modules/amc/AMC_PRE_BUILD_ARTIFACT_INDEX.md
@@ -2,7 +2,7 @@
 
 **Module**: App Management Centre (AMC)  
 **Lifecycle Model**: 12-Stage Pre-Build Sequence + Stage 5a (PRE_BUILD_STAGE_MODEL_CANON.md v1.0.0; AMC-GOV-OVERSIGHT-001)  
-**Last Updated**: 2026-07-01 (CS2 disposition pack for Stages 5, 5a, 6, and 7 added for review - PR #1194. Stage 7 PBFAG functional-delivery / deployment-execution / QA retrofit artifacts produced for CS2 review - wave amc-stage7-pbfag-retrofit-20260630; issue #1193; PR #1194. Prior: Stage 6 QA-to-Red functional-delivery retrofit merged as approval-pending reference input - issue #1191; PR #1192. Prior: Stage 5a retrofit merged as approval-pending reference input - issue #1189; PR #1190. Prior: Stage 5 architecture retrofit merged as approval-pending reference input - issue #1187; PR #1188. Prior: Stage 1-4 retrofit merged - issue #1185; PR #1186.)  
+**Last Updated**: 2026-07-02 (CS2 decision record for Stages 5, 5a, 6, and 7 prepared for PR review - issue #1197. Stage 8 is eligible to be opened next as a separate governed wave, but has not been started by this record.)  
 **Authority**: Maturion Foreman / CS2
 
 ---
@@ -60,15 +60,15 @@ This index catalogs all pre-build artifacts for the AMC module, mapped to their 
 
 | Artifact | Location | Status | Notes |
 |----------|----------|--------|-------|
-| Architecture Specification | `modules/amc/04-architecture/architecture-specification.md` | 🟡 Approval Pending | v1.0, produced 2026-04-26. CS2 approval required. |
-| TRS-to-Architecture Traceability | `modules/amc/04-architecture/trs-to-architecture-traceability.md` | 🟡 Approval Pending | v1.0, produced 2026-04-26. |
-| Functional Delivery Architecture Addendum | `modules/amc/04-architecture/functional-delivery-architecture-addendum.md` | 🟡 Retrofit Reference Input | Produced/merged in PR #1188. CS2 disposition required. |
-| Functional Delivery Architecture Map | `modules/amc/04-architecture/functional-delivery-architecture-map.md` | 🟡 Retrofit Reference Input | Produced/merged in PR #1188. Route/action/state/audit/degraded-mode map for Stage 6/7 derivation. CS2 disposition required. |
-| Stage 5 Functional Delivery Change-Propagation Audit | `modules/amc/04-architecture/stage5-functional-delivery-change-propagation-audit.md` | 🟡 Retrofit Reference Input | Produced/merged in PR #1188. Conditional pass for retrofit production; not build-ready and not Stage-8-ready. |
-| Stage 5 Review Notes | `modules/amc/04-architecture/stage5-review-notes.md` | 🟡 Retrofit Reference Input | Produced/merged in PR #1188. |
-| Stage 5 Coverage Note | `modules/amc/04-architecture/extra-review-note.md` | 🟡 Retrofit Reference Input | Produced/merged in PR #1188. |
+| Architecture Specification | `modules/amc/04-architecture/architecture-specification.md` | ✅ CS2 Approved with Conditions | v1.0, produced 2026-04-26. Approved by CS2 decision record in issue #1197; Stage 5 retrofit obligations remain binding inputs for Stage 8. |
+| TRS-to-Architecture Traceability | `modules/amc/04-architecture/trs-to-architecture-traceability.md` | ✅ CS2 Approved with Conditions | v1.0, produced 2026-04-26. Approved by CS2 decision record in issue #1197. |
+| Functional Delivery Architecture Addendum | `modules/amc/04-architecture/functional-delivery-architecture-addendum.md` | ✅ CS2 Approved with Conditions | Produced/merged in PR #1188. Binding Stage 8 input. |
+| Functional Delivery Architecture Map | `modules/amc/04-architecture/functional-delivery-architecture-map.md` | ✅ CS2 Approved with Conditions | Produced/merged in PR #1188. Route/action/state/audit/degraded-mode map remains binding for Stage 8. |
+| Stage 5 Functional Delivery Change-Propagation Audit | `modules/amc/04-architecture/stage5-functional-delivery-change-propagation-audit.md` | ✅ CS2 Approved with Conditions | Produced/merged in PR #1188. Conditions carried forward to Stage 8. |
+| Stage 5 Review Notes | `modules/amc/04-architecture/stage5-review-notes.md` | ✅ CS2 Approved with Conditions | Produced/merged in PR #1188. |
+| Stage 5 Coverage Note | `modules/amc/04-architecture/extra-review-note.md` | ✅ CS2 Approved with Conditions | Produced/merged in PR #1188. |
 | Architecture (superseded placeholder) | `modules/amc/04-architecture/architecture.md` | ⛔ Superseded | `architecture-specification.md` is the canonical Stage 5 artifact. |
-| Architecture Decision Records | `modules/amc/04-architecture/architecture-decision-records.md` | ⬜ Placeholder | Not started. |
+| Architecture Decision Records | `modules/amc/04-architecture/architecture-decision-records.md` | ⬜ Placeholder | Not started. Create later only if CS2 or Stage 8 requires ADRs. |
 | Architecture Completeness Checklist | `modules/amc/04-architecture/architecture-completeness-checklist.md` | ⬜ Placeholder | Not started / remains a placeholder unless separately populated. |
 
 ---
@@ -77,12 +77,12 @@ This index catalogs all pre-build artifacts for the AMC module, mapped to their 
 
 | Artifact | Location | Status | Notes |
 |----------|----------|--------|-------|
-| Deployment Execution Strategy | `modules/amc/05a-deployment-execution-strategy/deployment-execution-strategy.md` | 🟡 Approval Pending | v1.0, produced 2026-04-27. CS2 approval required. |
-| Deployment Surface Ownership Table | `modules/amc/05a-deployment-execution-strategy/deployment-surface-ownership-table.md` | 🟡 Approval Pending | v1.0, produced 2026-04-27. |
-| Runner and Environment Constraints | `modules/amc/05a-deployment-execution-strategy/runner-and-environment-constraints.md` | 🟡 Approval Pending | v1.0, produced 2026-04-27. |
-| Functional Delivery Deployment Execution Addendum | `modules/amc/05a-deployment-execution-strategy/functional-delivery-deployment-execution-addendum.md` | 🟡 Retrofit Reference Input | Produced/merged in PR #1190. Imports TR-1910, Stage 5 architecture map, deployment evidence, runtime health/smoke validation, dependency readiness, and no-operational-speculation controls. CS2 disposition required. |
-| Deployment Execution Validation Matrix | `modules/amc/05a-deployment-execution-strategy/deployment-execution-validation-matrix.md` | 🟡 Retrofit Reference Input | Produced/merged in PR #1190. Adds workflow, environment, migration, protected approval, health, rollback, dependency, audit, and evidence validation obligations for Stage 6/7 derivation. CS2 disposition required. |
-| Stage 5a Functional Delivery Change-Propagation Audit | `modules/amc/05a-deployment-execution-strategy/stage5a-functional-delivery-change-propagation-audit.md` | 🟡 Retrofit Reference Input | Produced/merged in PR #1190. Conditional pass for Stage 5a retrofit production; not build-ready and not Stage-8-ready. |
+| Deployment Execution Strategy | `modules/amc/05a-deployment-execution-strategy/deployment-execution-strategy.md` | ✅ CS2 Approved with Conditions | v1.0, produced 2026-04-27. Approved by CS2 decision record in issue #1197. |
+| Deployment Surface Ownership Table | `modules/amc/05a-deployment-execution-strategy/deployment-surface-ownership-table.md` | ✅ CS2 Approved with Conditions | v1.0, produced 2026-04-27. Deployment ownership remains binding for Stage 8. |
+| Runner and Environment Constraints | `modules/amc/05a-deployment-execution-strategy/runner-and-environment-constraints.md` | ✅ CS2 Approved with Conditions | v1.0, produced 2026-04-27. Runner and environment constraints remain binding for Stage 8. |
+| Functional Delivery Deployment Execution Addendum | `modules/amc/05a-deployment-execution-strategy/functional-delivery-deployment-execution-addendum.md` | ✅ CS2 Approved with Conditions | Produced/merged in PR #1190. Binding Stage 8 input. |
+| Deployment Execution Validation Matrix | `modules/amc/05a-deployment-execution-strategy/deployment-execution-validation-matrix.md` | ✅ CS2 Approved with Conditions | Produced/merged in PR #1190. Deployment, CI, preview, secret, migration, rollback, health/smoke, and dependency conditions remain binding for Stage 8. |
+| Stage 5a Functional Delivery Change-Propagation Audit | `modules/amc/05a-deployment-execution-strategy/stage5a-functional-delivery-change-propagation-audit.md` | ✅ CS2 Approved with Conditions | Produced/merged in PR #1190. Conditions carried forward to Stage 8. |
 | Governance Oversight Record | `modules/amc/governance-oversight/DEPLOYMENT_STRATEGY_OVERSIGHT.md` | ✅ Complete | Formal oversight record. CS2 auth: #1133. |
 
 ---
@@ -91,12 +91,12 @@ This index catalogs all pre-build artifacts for the AMC module, mapped to their 
 
 | Artifact | Location | Status | Notes |
 |----------|----------|--------|-------|
-| QA-to-Red Specification | `modules/amc/05-qa-to-red/qa-to-red-specification.md` | 🟡 Approval Pending | v1.0, produced 2026-04-27. Must be reviewed with Stage 6 retrofit artifacts. |
-| Architecture and DES to QA Traceability | `modules/amc/05-qa-to-red/architecture-and-des-to-qa-traceability.md` | 🟡 Approval Pending | v1.0, produced 2026-04-27. Must be reconciled with Stage 5/5a retrofit maps before Stage 8. |
-| Red Test Catalog | `modules/amc/05-qa-to-red/red-test-catalog.md` | 🟡 Approval Pending | v1.0, produced 2026-04-27. 79 test cases across 20 families. Retrofit adds QA-FD and QA-DEPLOY families. |
-| Functional Delivery QA-to-Red Addendum | `modules/amc/05-qa-to-red/functional-delivery-qa-to-red-addendum.md` | 🟡 Retrofit Reference Input | Produced/merged in PR #1192. Imports Stage 1-5a functional-delivery and deployment-execution obligations into Stage 6. CS2 disposition required. |
-| Functional Delivery RED Test Expansion Matrix | `modules/amc/05-qa-to-red/functional-delivery-red-test-expansion-matrix.md` | 🟡 Retrofit Reference Input | Produced/merged in PR #1192. Defines QA-FD and QA-DEPLOY RED test families. CS2 disposition required. |
-| Stage 6 Functional Delivery Change-Propagation Audit | `modules/amc/05-qa-to-red/stage6-functional-delivery-change-propagation-audit.md` | 🟡 Retrofit Reference Input | Produced/merged in PR #1192. Conditional pass for Stage 6 retrofit production; not build-ready and not Stage-8-ready. |
+| QA-to-Red Specification | `modules/amc/05-qa-to-red/qa-to-red-specification.md` | ✅ CS2 Approved with Conditions | v1.0, produced 2026-04-27. Approved by CS2 decision record in issue #1197. |
+| Architecture and DES to QA Traceability | `modules/amc/05-qa-to-red/architecture-and-des-to-qa-traceability.md` | ✅ CS2 Approved with Conditions | v1.0, produced 2026-04-27. Must be carried into Stage 8 implementation planning. |
+| Red Test Catalog | `modules/amc/05-qa-to-red/red-test-catalog.md` | ✅ CS2 Approved with Conditions | v1.0, produced 2026-04-27. 79 test cases across 20 families. Retrofit adds QA-FD and QA-DEPLOY families. |
+| Functional Delivery QA-to-Red Addendum | `modules/amc/05-qa-to-red/functional-delivery-qa-to-red-addendum.md` | ✅ CS2 Approved with Conditions | Produced/merged in PR #1192. Binding Stage 8 input. |
+| Functional Delivery RED Test Expansion Matrix | `modules/amc/05-qa-to-red/functional-delivery-red-test-expansion-matrix.md` | ✅ CS2 Approved with Conditions | Produced/merged in PR #1192. QA-FD and QA-DEPLOY rows remain binding for Stage 8. |
+| Stage 6 Functional Delivery Change-Propagation Audit | `modules/amc/05-qa-to-red/stage6-functional-delivery-change-propagation-audit.md` | ✅ CS2 Approved with Conditions | Produced/merged in PR #1192. Conditions carried forward to Stage 8. |
 | QA-to-Red Suite (superseded placeholder) | `modules/amc/05-qa-to-red/qa-to-red-suite.md` | ⛔ Superseded | Placeholder superseded by qa-to-red-specification.md v1.0. |
 | QA Catalog Alignment (superseded placeholder) | `modules/amc/05-qa-to-red/qa-catalog-alignment.md` | ⛔ Superseded | Placeholder superseded by architecture-and-des-to-qa-traceability.md v1.0. |
 
@@ -106,15 +106,16 @@ This index catalogs all pre-build artifacts for the AMC module, mapped to their 
 
 | Artifact | Location | Status | Notes |
 |----------|----------|--------|-------|
-| Pre-Build Final Assurance Gate | `modules/amc/06-pbfag/pre-build-final-assurance-gate.md` | 🟡 Approval Pending | Must be reconciled with Stage 5/5a/6 retrofit obligations before Stage 8. |
-| PBFAG Evidence Matrix | `modules/amc/06-pbfag/pbfag-evidence-matrix.md` | 🟡 Approval Pending | Must include tracker/index agreement for new retrofit artifacts before final Stage 8 disposition. |
-| PBFAG Findings and Verdict | `modules/amc/06-pbfag/pbfag-findings-and-verdict.md` | 🟡 Approval Pending | Stage 8 gate remains conditional. |
-| PBFAG Checklist | `modules/amc/06-pbfag/pbfag-checklist.md` | 🟡 Approval Pending | References canonical PBFAG artifacts. |
-| Stage 1-4 Functional Delivery Change-Propagation Audit | `modules/amc/06-pbfag/stage1-4-functional-delivery-change-propagation-audit.md` | 🟡 Retrofit Reference Input | Produced/merged in PR #1186 chain and retained as upstream disposition input. CS2 disposition required. |
-| Functional Delivery PBFAG Addendum | `modules/amc/06-pbfag/functional-delivery-pbfag-addendum.md` | 🟡 Retrofit Produced for CS2 Review | Produced in issue #1193 / PR #1194. Imports Stage 5/5a/6 retrofit obligations into Stage 7. |
-| PBFAG Retrofit Evidence Matrix | `modules/amc/06-pbfag/pbfag-retrofit-evidence-matrix.md` | 🟡 Retrofit Produced for CS2 Review | Produced in issue #1193 / PR #1194. Maps Stage 5/5a/6 obligations to PBFAG gate checks. |
-| Stage 7 Functional Delivery Change-Propagation Audit | `modules/amc/06-pbfag/stage7-functional-delivery-change-propagation-audit.md` | 🟡 Retrofit Produced for CS2 Review | Produced in issue #1193 / PR #1194. Conditional pass for Stage 7 retrofit production; not build-ready and not Stage-8-ready. |
-| CS2 Disposition Pack - Stages 5, 5a, 6, and 7 | `modules/amc/06-pbfag/cs2-disposition-pack-stages-5-5a-6-7.md` | 🟡 Prepared for CS2 Review | Produced in PR #1194. Summarises readiness, blockers, risks, conditions, and recommended CS2 disposition. Does not authorize Stage 8. |
+| Pre-Build Final Assurance Gate | `modules/amc/06-pbfag/pre-build-final-assurance-gate.md` | ✅ CS2 Approved with Conditions | Approved by CS2 decision record in issue #1197. Conditions remain binding for Stage 8. |
+| PBFAG Evidence Matrix | `modules/amc/06-pbfag/pbfag-evidence-matrix.md` | ✅ CS2 Approved with Conditions | Tracker/index agreement and Stage 8 gate conditions remain binding. |
+| PBFAG Findings and Verdict | `modules/amc/06-pbfag/pbfag-findings-and-verdict.md` | ✅ CS2 Approved with Conditions | Stage 8 may be opened next only as a separate governed wave. |
+| PBFAG Checklist | `modules/amc/06-pbfag/pbfag-checklist.md` | ✅ CS2 Approved with Conditions | References canonical PBFAG artifacts. |
+| Stage 1-4 Functional Delivery Change-Propagation Audit | `modules/amc/06-pbfag/stage1-4-functional-delivery-change-propagation-audit.md` | ✅ CS2 Approved with Conditions | Produced/merged in PR #1186 chain and retained as upstream input. |
+| Functional Delivery PBFAG Addendum | `modules/amc/06-pbfag/functional-delivery-pbfag-addendum.md` | ✅ CS2 Approved with Conditions | Produced in issue #1193 / PR #1194. Binding Stage 8 input. |
+| PBFAG Retrofit Evidence Matrix | `modules/amc/06-pbfag/pbfag-retrofit-evidence-matrix.md` | ✅ CS2 Approved with Conditions | PBFAG-FD, PBFAG-DEPLOY, PBFAG-QA, PBFAG-TRACK, and PBFAG-STAGE8 rows remain binding for Stage 8. |
+| Stage 7 Functional Delivery Change-Propagation Audit | `modules/amc/06-pbfag/stage7-functional-delivery-change-propagation-audit.md` | ✅ CS2 Approved with Conditions | Conditions carried forward to Stage 8. |
+| CS2 Disposition Pack - Stages 5, 5a, 6, and 7 | `modules/amc/06-pbfag/cs2-disposition-pack-stages-5-5a-6-7.md` | ✅ Used for CS2 Decision | Produced in PR #1194. Source for issue #1197 decision record. |
+| CS2 Decision Record - Stages 5, 5a, 6, and 7 | `modules/amc/06-pbfag/cs2-decision-record-stages-5-5a-6-7.md` | ✅ Prepared for CS2 Review | Produced in issue #1197. Records explicit CS2 approval with conditions. Does not authorize implementation or build. |
 
 ---
 
@@ -122,7 +123,7 @@ This index catalogs all pre-build artifacts for the AMC module, mapped to their 
 
 | Artifact | Location | Status | Notes |
 |----------|----------|--------|-------|
-| Implementation Plan | `modules/amc/07-implementation-plan/implementation-plan.md` | ⬜ Placeholder | Not started. |
+| Implementation Plan | `modules/amc/07-implementation-plan/implementation-plan.md` | ⬜ Placeholder | Not started. Eligible to be opened next only by separate Stage 8 issue/PR. |
 | Wave Breakdown | `modules/amc/07-implementation-plan/wave-breakdown.md` | ⬜ Placeholder | Not started. |
 
 ---

--- a/modules/amc/BUILD_PROGRESS_TRACKER.md
+++ b/modules/amc/BUILD_PROGRESS_TRACKER.md
@@ -2,24 +2,24 @@
 
 **Module**: App Management Centre (AMC)  
 **Module Slug**: AMC  
-**Last Updated**: 2026-07-01  
-**Updated By**: foreman-v2-agent (wave: amc-stage7-pbfag-retrofit-20260630 - issue #1193; PR #1194; CS2 disposition pack for Stages 5, 5a, 6, and 7 prepared. Stage 8 and all build-readiness stages remain blocked.)
+**Last Updated**: 2026-07-02  
+**Updated By**: foreman-v2-agent (wave: amc-cs2-disposition-stages-5-7 - issue #1197; CS2 decision record for Stages 5, 5a, 6, and 7 prepared. Stage 8 is eligible to be opened next as a separate governed wave, but this PR does not start Stage 8.)
 
 > **Classification**: ACTIVE  
 > **Document Role**: PRIMARY LIVE CONTROL DOCUMENT - CS2 should use this document as the main live progress dashboard.  
 > **Canon Reference**: `PRE_BUILD_STAGE_MODEL_CANON.md` v1.0.0 plus current ISMS/MMM functional-delivery retrofit lessons  
-> **Current Issue**: [app_management_centre#1193](https://github.com/APGI-cmy/app_management_centre/issues/1193)  
-> **Current PR**: [app_management_centre#1194](https://github.com/APGI-cmy/app_management_centre/pull/1194)  
+> **Current Issue**: [app_management_centre#1197](https://github.com/APGI-cmy/app_management_centre/issues/1197)  
+> **Current PR**: pending CS2 disposition PR creation  
 > **Update Rule**: This document MUST be updated immediately after every AMC stage issue, wave completion, approval, or readiness/blocker change. Stale tracker text is a governance defect.
 
-## Retrofit Notes
+## Retrofit and Disposition Notes
 
 - PR #1186 merged Stage 1-4 functional-delivery reference inputs.
-- PR #1188 merged Stage 5 architecture retrofit reference inputs. Stage 5 remains approval-pending.
-- PR #1190 merged Stage 5a deployment-execution retrofit reference inputs. Stage 5a remains approval-pending.
-- PR #1192 merged Stage 6 QA-to-Red retrofit reference inputs. Stage 6 remains approval-pending.
-- Issue #1193 / PR #1194 imports Stage 5 route/action/state/audit/degraded-mode obligations, Stage 5a deployment-execution obligations, and Stage 6 QA-FD / QA-DEPLOY obligations into Stage 7 PBFAG.
-- PR #1194 now includes `cs2-disposition-pack-stages-5-5a-6-7.md` to support CS2 disposition of Stages 5, 5a, 6, and 7 without starting Stage 8.
+- PR #1188 merged Stage 5 architecture retrofit reference inputs.
+- PR #1190 merged Stage 5a deployment-execution retrofit reference inputs.
+- PR #1192 merged Stage 6 QA-to-Red retrofit reference inputs.
+- PR #1194 merged Stage 7 PBFAG retrofit artifacts and `cs2-disposition-pack-stages-5-5a-6-7.md`.
+- Issue #1197 records the explicit CS2 decision approving Stages 5, 5a, 6, and 7 with conditions.
 
 ---
 
@@ -31,11 +31,11 @@
 | 2 | UX Workflow & Wiring Spec | ✅ COMPLETE + 🟡 RETROFIT ADDENDUM PRODUCED | CS2-approved 2026-04-22. CTA/API/Data/Audit matrix merged in #1186. |
 | 3 | FRS | ✅ COMPLETE - CS2 APPROVED + 🟡 RETROFIT ADDENDUM PRODUCED | FR-1900 merged in #1186. |
 | 4 | TRS | ✅ TREATED AS APPROVED + 🟡 RETROFIT ADDENDUM PRODUCED | TR-1900, including TR-1910, merged in #1186. |
-| 5 | Architecture | 🟡 IN PROGRESS — Produced Approval-Pending | Ready for CS2 disposition via PR #1194 pack; merge is not Stage 5 approval. |
-| 5a | Deployment Execution Strategy | 🟡 IN PROGRESS — Produced Approval-Pending | Ready for CS2 disposition via PR #1194 pack; merge is not Stage 5a approval. |
-| 6 | QA-to-Red | 🟡 IN PROGRESS — Produced Approval-Pending | Ready for CS2 disposition via PR #1194 pack; merge is not Stage 6 approval. |
-| **7** | **PBFAG** | **🟡 IN PROGRESS — Produced Approval-Pending** | PR #1194 imports Stage 5/5a/6 retrofit controls and includes CS2 disposition pack. |
-| 8 | Implementation Plan | ⬜ Not Started — 🔴 BLOCKED | Must not start until Stages 5, 5a, 6, and 7 are CS2-dispositioned by explicit CS2 action. |
+| 5 | Architecture | ✅ CS2 APPROVED WITH CONDITIONS | Stage 5 retrofit obligations remain binding inputs for Stage 8. |
+| 5a | Deployment Execution Strategy | ✅ CS2 APPROVED WITH CONDITIONS | Deployment validation, CI, preview, secret, migration, rollback, health/smoke, and dependency conditions remain binding inputs for Stage 8. |
+| 6 | QA-to-Red | ✅ CS2 APPROVED WITH CONDITIONS | QA-FD and QA-DEPLOY rows remain binding inputs for Stage 8 and later QA-to-Green evidence. |
+| **7** | **PBFAG** | **✅ CS2 APPROVED WITH CONDITIONS** | PBFAG-FD, PBFAG-DEPLOY, PBFAG-QA, tracker/index, and Stage 8 block rows remain binding inputs for Stage 8. |
+| 8 | Implementation Plan | ⬜ Not Started — 🟡 ELIGIBLE NEXT | May be opened only by a separate Stage 8 issue/PR that imports the CS2 decision record and all conditions. |
 | 9 | Builder Checklist | ⬜ Not Started — 🔴 BLOCKED | Blocked until Stage 8 is authorized and complete. |
 | 10 | IAA Pre-Brief | ⬜ Not Started — 🔴 BLOCKED | Blocked until canonical sequence authorizes it. |
 | 11 | Builder Appointment | ⬜ Not Started — 🔴 BLOCKED | No builders appointed. |
@@ -43,32 +43,43 @@
 
 ---
 
-## Stage 7 - PBFAG
+## CS2 Disposition Record
 
-**Status**: 🟡 IN PROGRESS — Produced Approval-Pending  
-**Location**: `modules/amc/06-pbfag/`
+**Status**: Prepared for PR review  
+**Location**: `modules/amc/06-pbfag/cs2-decision-record-stages-5-5a-6-7.md`
 
-**Key Artifacts and Hard-Gate Inputs**:
-- [x] `pre-build-final-assurance-gate.md`
-- [x] `pbfag-evidence-matrix.md`
-- [x] `pbfag-findings-and-verdict.md`
-- [x] `pbfag-checklist.md`
-- [x] `stage1-4-functional-delivery-change-propagation-audit.md`
-- [x] `functional-delivery-architecture-map.md` - Stage 5 hard-gate input
-- [x] `deployment-execution-validation-matrix.md` - Stage 5a hard-gate input
-- [x] `functional-delivery-red-test-expansion-matrix.md` - Stage 6 QA-FD / QA-DEPLOY hard-gate input
-- [x] `functional-delivery-pbfag-addendum.md` - produced in issue #1193 / PR #1194
-- [x] `pbfag-retrofit-evidence-matrix.md` - produced in issue #1193 / PR #1194
-- [x] `stage7-functional-delivery-change-propagation-audit.md` - produced in issue #1193 / PR #1194
-- [x] `cs2-disposition-pack-stages-5-5a-6-7.md` - produced in PR #1194 for CS2 disposition review
+**Decision summary**:
+- Stage 5 Architecture: approved with conditions.
+- Stage 5a Deployment Execution Strategy: approved with conditions.
+- Stage 6 QA-to-Red: approved with conditions.
+- Stage 7 PBFAG: approved with conditions.
 
-**Current gate note**: Stage 7 must import Stage 5/5a/6 retrofit obligations and fail or condition Stage 8 if material action coverage, deployment execution, route/event authority, evidence package, QA coverage, or placeholder controls remain unresolved. This tracker update does not approve Stage 7 or authorize Stage 8.
+**Boundary**: This tracker update does not start Stage 8, does not create implementation work, does not appoint builders, and does not authorize build.
+
+---
+
+## Stage 8 Eligibility Conditions
+
+Any later Stage 8 issue and implementation plan must import:
+
+1. `cs2-decision-record-stages-5-5a-6-7.md`.
+2. Stage 5 route/action/state/audit/degraded-mode map.
+3. Stage 5a deployment validation matrix, including CI and preview boundaries.
+4. Stage 6 QA-FD and QA-DEPLOY rows.
+5. Stage 7 PBFAG-FD, PBFAG-DEPLOY, PBFAG-QA, PBFAG-TRACK, and PBFAG-STAGE8 rows.
+6. First E2E `/alerts` acknowledgement path.
+7. Placeholder/stub rejection rule.
+8. Production approval gates and secret separation.
+9. Supabase migration command freeze.
+10. Rollback evidence planning.
+11. Runtime health/smoke validation.
+12. External dependency readiness and visible degraded-mode behavior.
+13. Complete implementation evidence package.
 
 ---
 
 ## Blocked Downstream Stages
 
-- Stage 8 Implementation Plan: not started and blocked.
 - Stage 9 Builder Checklist: not started and blocked.
 - Stage 10 IAA Pre-Brief: not started and blocked.
 - Stage 11 Builder Appointment: not started and blocked.
@@ -78,24 +89,19 @@
 
 ## Next Action
 
-1. Review PR #1194 including the CS2 disposition pack.
-2. CS2 to disposition Stages 5, 5a, 6, and 7 explicitly.
-3. Do not start Stage 8 from this PR.
-4. Do not appoint builders until the canonical pre-build sequence authorizes Stage 11.
+1. Review and merge the CS2 disposition record PR for issue #1197.
+2. After merge, Stage 8 may be opened as a separate governed Stage 8 implementation-planning wave.
+3. Do not create builder checklist, IAA pre-brief, builder appointment, or build work from this PR.
 
 ---
 
 ## References
 
 - [PRE_BUILD_STAGE_MODEL_CANON.md](../../governance/canon/PRE_BUILD_STAGE_MODEL_CANON.md)
+- [cs2-disposition-pack-stages-5-5a-6-7.md](./06-pbfag/cs2-disposition-pack-stages-5-5a-6-7.md)
+- [cs2-decision-record-stages-5-5a-6-7.md](./06-pbfag/cs2-decision-record-stages-5-5a-6-7.md)
 - [functional-delivery-architecture-map.md](./04-architecture/functional-delivery-architecture-map.md)
 - [deployment-execution-validation-matrix.md](./05a-deployment-execution-strategy/deployment-execution-validation-matrix.md)
 - [functional-delivery-red-test-expansion-matrix.md](./05-qa-to-red/functional-delivery-red-test-expansion-matrix.md)
-- [pre-build-final-assurance-gate.md](./06-pbfag/pre-build-final-assurance-gate.md)
-- [pbfag-evidence-matrix.md](./06-pbfag/pbfag-evidence-matrix.md)
-- [pbfag-findings-and-verdict.md](./06-pbfag/pbfag-findings-and-verdict.md)
-- [functional-delivery-pbfag-addendum.md](./06-pbfag/functional-delivery-pbfag-addendum.md)
 - [pbfag-retrofit-evidence-matrix.md](./06-pbfag/pbfag-retrofit-evidence-matrix.md)
-- [stage7-functional-delivery-change-propagation-audit.md](./06-pbfag/stage7-functional-delivery-change-propagation-audit.md)
-- [cs2-disposition-pack-stages-5-5a-6-7.md](./06-pbfag/cs2-disposition-pack-stages-5-5a-6-7.md)
 - [AMC_PRE_BUILD_ARTIFACT_INDEX.md](./AMC_PRE_BUILD_ARTIFACT_INDEX.md)

--- a/modules/amc/BUILD_PROGRESS_TRACKER.md
+++ b/modules/amc/BUILD_PROGRESS_TRACKER.md
@@ -3,13 +3,13 @@
 **Module**: App Management Centre (AMC)  
 **Module Slug**: AMC  
 **Last Updated**: 2026-07-02  
-**Updated By**: foreman-v2-agent (wave: amc-cs2-disposition-stages-5-7 - issue #1197; CS2 decision record for Stages 5, 5a, 6, and 7 prepared. Stage 8 is eligible to be opened next as a separate governed wave, but this PR does not start Stage 8.)
+**Updated By**: foreman-v2-agent (wave: amc-cs2-disposition-stages-5-7 - issue #1197; PR #1198; CS2 decision record for Stages 5, 5a, 6, and 7 prepared. Stage 8 is eligible to be opened next as a separate governed wave, but this PR does not start Stage 8.)
 
 > **Classification**: ACTIVE  
 > **Document Role**: PRIMARY LIVE CONTROL DOCUMENT - CS2 should use this document as the main live progress dashboard.  
 > **Canon Reference**: `PRE_BUILD_STAGE_MODEL_CANON.md` v1.0.0 plus current ISMS/MMM functional-delivery retrofit lessons  
 > **Current Issue**: [app_management_centre#1197](https://github.com/APGI-cmy/app_management_centre/issues/1197)  
-> **Current PR**: pending CS2 disposition PR creation  
+> **Current PR**: [app_management_centre#1198](https://github.com/APGI-cmy/app_management_centre/pull/1198)  
 > **Update Rule**: This document MUST be updated immediately after every AMC stage issue, wave completion, approval, or readiness/blocker change. Stale tracker text is a governance defect.
 
 ## Retrofit and Disposition Notes
@@ -19,7 +19,7 @@
 - PR #1190 merged Stage 5a deployment-execution retrofit reference inputs.
 - PR #1192 merged Stage 6 QA-to-Red retrofit reference inputs.
 - PR #1194 merged Stage 7 PBFAG retrofit artifacts and `cs2-disposition-pack-stages-5-5a-6-7.md`.
-- Issue #1197 records the explicit CS2 decision approving Stages 5, 5a, 6, and 7 with conditions.
+- Issue #1197 / PR #1198 records the explicit CS2 decision approving Stages 5, 5a, 6, and 7 with conditions.
 
 ---
 


### PR DESCRIPTION
## Summary

governing_issue: #1197

This PR records the explicit CS2 disposition required after PR #1194 merged.

It records CS2 approval with conditions for:

1. Stage 5 Architecture;
2. Stage 5a Deployment Execution Strategy;
3. Stage 6 QA-to-Red;
4. Stage 7 PBFAG.

## Added / updated artifacts

1. `modules/amc/06-pbfag/cs2-decision-record-stages-5-5a-6-7.md`
   - Formal CS2 decision record approving Stages 5, 5a, 6, and 7 with conditions.
   - Carries Stage 5/5a/6/7 conditions forward to any later Stage 8 wave.

2. `modules/amc/BUILD_PROGRESS_TRACKER.md`
   - Updates Stages 5, 5a, 6, and 7 to CS2 approved with conditions.
   - Marks Stage 8 as eligible next, but not started.
   - Keeps Stages 9-12 blocked.

3. `modules/amc/AMC_PRE_BUILD_ARTIFACT_INDEX.md`
   - Updates the artifact authority status for Stages 5, 5a, 6, and 7.
   - Adds the CS2 decision record.
   - Keeps Stage 8 implementation plan as a placeholder.

4. `.agent-admin/wave-records/amc-wave-record-1197-current.md`
   - Safe wave record for the disposition-record update.

## Governance boundary

This PR does not:

- begin Stage 8;
- create the Stage 8 implementation plan;
- create implementation work;
- create builder checklist;
- create IAA pre-brief;
- appoint builders;
- certify build-readiness;
- start build.

## Stage 8 posture

After this decision record is merged, Stage 8 may be opened next only as a separate governed issue and PR that imports the CS2 decision record and all attached conditions.

Closes #1197.