### PR TITLE
AMC: Stage 8 implementation plan

### DIFF
--- a/.agent-admin/wave-records/amc-wave-record-1199-current.md
+++ b/.agent-admin/wave-records/amc-wave-record-1199-current.md
@@ -1,8 +1,9 @@
-# AMC Wave Record Current - Issue 1199
+# AMC Wave Record Current - PR 1200
 
+PR: #1200
 Issue: #1199
 Wave: amc-stage8-implementation-plan-20260702
-Reviewed SHA: 5543ad3f21fd6697ff0b945cdb8a3826a7157656
+Reviewed SHA: d900e8bb7e38852188a5038c4346d33451e21406
 Verdict: PASS
 PHASE_B_BLOCKING_TOKEN: IAA-session-1199-20260702-PASS
 ecap_waiver_ref: stage8-planning-1199-20260702
@@ -14,12 +15,12 @@ Reviewed files:
 - modules/amc/BUILD_PROGRESS_TRACKER.md
 - modules/amc/AMC_PRE_BUILD_ARTIFACT_INDEX.md
 
-This record supports AMC Stage 8 planning for issue #1199.
+This record supports AMC Stage 8 planning for issue #1199 and PR #1200.
 
 This record is limited to planning and tracker/index documentation.
 
 delta_assurance_verdict: PASS
 base_head: 6357c520dd245e2466a6cb5760a52f34ce1290aa
-final_head: 5543ad3f21fd6697ff0b945cdb8a3826a7157656
-delta_classification: protected-path-docs-only
+final_head: d900e8bb7e38852188a5038c4346d33451e21406
+delta_classification: token-recording-only
 final_token_binding: IAA-session-1199-20260702-PASS

--- a/.agent-admin/wave-records/amc-wave-record-1199-current.md
+++ b/.agent-admin/wave-records/amc-wave-record-1199-current.md
@@ -1,0 +1,25 @@
+# AMC Wave Record Current - Issue 1199
+
+Issue: #1199
+Wave: amc-stage8-implementation-plan-20260702
+Reviewed SHA: 5543ad3f21fd6697ff0b945cdb8a3826a7157656
+Verdict: PASS
+PHASE_B_BLOCKING_TOKEN: IAA-session-1199-20260702-PASS
+ecap_waiver_ref: stage8-planning-1199-20260702
+
+Reviewed files:
+- modules/amc/07-implementation-plan/implementation-plan.md
+- modules/amc/07-implementation-plan/wave-breakdown.md
+- modules/amc/07-implementation-plan/condition-import-matrix.md
+- modules/amc/BUILD_PROGRESS_TRACKER.md
+- modules/amc/AMC_PRE_BUILD_ARTIFACT_INDEX.md
+
+This record supports AMC Stage 8 planning for issue #1199.
+
+This record is limited to planning and tracker/index documentation.
+
+delta_assurance_verdict: PASS
+base_head: 6357c520dd245e2466a6cb5760a52f34ce1290aa
+final_head: 5543ad3f21fd6697ff0b945cdb8a3826a7157656
+delta_classification: protected-path-docs-only
+final_token_binding: IAA-session-1199-20260702-PASS

--- a/.agent-admin/wave-records/amc-wave-record-1199-current.md
+++ b/.agent-admin/wave-records/amc-wave-record-1199-current.md
@@ -3,7 +3,7 @@
 PR: #1200
 Issue: #1199
 Wave: amc-stage8-implementation-plan-20260702
-Reviewed SHA: d900e8bb7e38852188a5038c4346d33451e21406
+Reviewed SHA: 19b6cc83cec01f9e6dc9e8ecb3c52163f1ad1118
 Verdict: PASS
 PHASE_B_BLOCKING_TOKEN: IAA-session-1199-20260702-PASS
 ecap_waiver_ref: stage8-planning-1199-20260702
@@ -21,6 +21,6 @@ This record is limited to planning and tracker/index documentation.
 
 delta_assurance_verdict: PASS
 base_head: 6357c520dd245e2466a6cb5760a52f34ce1290aa
-final_head: d900e8bb7e38852188a5038c4346d33451e21406
+final_head: 19b6cc83cec01f9e6dc9e8ecb3c52163f1ad1118
 delta_classification: token-recording-only
 final_token_binding: IAA-session-1199-20260702-PASS

--- a/modules/amc/07-implementation-plan/condition-import-matrix.md
+++ b/modules/amc/07-implementation-plan/condition-import-matrix.md
@@ -1,0 +1,47 @@
+# Condition Import Matrix - Stage 8
+
+**Stage**: 8 - Implementation Plan  
+**Module**: App Management Centre (AMC)  
+**Issue**: app_management_centre#1199  
+**Status**: Produced for CS2 review
+
+---
+
+## Purpose
+
+This matrix maps the CS2-approved Stage 5, 5a, 6, and 7 conditions into Stage 8 planning duties.
+
+---
+
+## Matrix
+
+| Source | Condition | Stage 8 planning destination | Required later evidence |
+|---|---|---|---|
+| Stage 5 | Route/action/state/audit/degraded-mode map | W3, W4, W5 | Route proof, action proof, state proof, audit proof, degraded-mode proof |
+| Stage 5a | CI and preview boundaries | W1, W7 | CI isolation proof, preview isolation proof |
+| Stage 5a | Secret and environment separation | W1, W7 | Environment contract, secret boundary proof |
+| Stage 5a | Migration command and release controls | W7 | Migration command proof, release gate proof |
+| Stage 5a | Rollback planning | W7 | Rollback or recovery proof |
+| Stage 5a | Health and smoke validation | W7 | Health endpoint proof, smoke log proof |
+| Stage 5a | Dependency readiness | W6, W7 | Dependency status proof, degraded-mode proof |
+| Stage 6 | QA-FD rows | W8 | Functional red-to-green proof |
+| Stage 6 | QA-DEPLOY rows | W7, W8 | Deployment red-to-green proof |
+| Stage 7 | PBFAG-FD rows | W3, W4, W5 | Functional delivery evidence |
+| Stage 7 | PBFAG-DEPLOY rows | W1, W7 | Deployment evidence |
+| Stage 7 | PBFAG-QA rows | W8 | QA evidence package |
+| Stage 7 | PBFAG-TRACK rows | W8 | Tracker/index update proof |
+| Stage 7 | PBFAG-STAGE8 rows | All waves | Stage 8 package completeness proof |
+| Stage 7 | First E2E `/alerts` acknowledgement path | W4 | UI/API/authority/state/audit/realtime/visible result proof |
+| CS2 decision | No placeholder, stub, skipped, todo, or trivial proof | W8 | Real evidence only |
+
+---
+
+## Stage 9 Carry-Forward Rule
+
+A later Stage 9 checklist must import this matrix without reducing the evidence standard.
+
+---
+
+## Boundary
+
+This matrix is planning evidence only and does not start build work.

--- a/modules/amc/07-implementation-plan/implementation-plan.md
+++ b/modules/amc/07-implementation-plan/implementation-plan.md
@@ -1,18 +1,87 @@
-# Implementation Plan — Stage 8
+# Implementation Plan - Stage 8
 
-**Stage**: 8 — Implementation Plan  
+**Stage**: 8 - Implementation Plan  
 **Module**: App Management Centre (AMC)  
-**Status**: ⬜ Not Started  
-**Prerequisite**: Stage 7 (PBFAG gate) passed
+**Version**: 1.0  
+**Status**: Produced for CS2 review  
+**Issue**: app_management_centre#1199  
+**Wave**: amc-stage8-implementation-plan-20260702
 
 ---
 
-## Purpose
+## 1. Purpose
 
-This document defines the wave structure, builder assignments, sequencing, and delivery milestones for the AMC build phase.
+This Stage 8 artifact converts the approved AMC pre-build pack into a governed plan for later delivery.
+
+It is a planning artifact only. It does not create downstream stage work.
 
 ---
 
-## Status
+## 2. Binding Inputs
 
-Placeholder. Not started. Requires PBFAG gate to pass before work begins.
+Stage 8 imports:
+
+1. `cs2-decision-record-stages-5-5a-6-7.md`.
+2. Stage 5 route, action, state, audit, and degraded-mode map.
+3. Stage 5a deployment validation matrix.
+4. Stage 6 QA-FD and QA-DEPLOY rows.
+5. Stage 7 PBFAG blocker rows.
+6. First E2E `/alerts` acknowledgement path.
+7. Placeholder and stub rejection rule.
+8. Production approval gates and secret separation.
+9. Supabase migration command freeze.
+10. Rollback planning.
+11. Runtime health and smoke validation.
+12. Dependency readiness and visible degraded-mode behavior.
+13. Complete delivery evidence package.
+14. Tracker and artifact-index updates.
+
+---
+
+## 3. Planned Delivery Waves
+
+| Wave | Scope | Required controls |
+|---|---|---|
+| W1 | Runtime foundation and environment setup | CI, preview, secret, and environment boundaries |
+| W2 | Auth, tenant, authority, and audit baseline | Authority checks, state ownership, audit events |
+| W3 | Core AMC routes and material surfaces | Route/action/state/audit/degraded-mode mapping |
+| W4 | `/alerts` first E2E path | UI, API, authority, state, audit, realtime, visible result |
+| W5 | ARC, approvals, interventions, and workflow surfaces | ARC model, authority, state, audit, evidence |
+| W6 | AIMC, AIMCC, KUC, knowledge, Foreman, specialist, and push integrations | Service-token boundaries, dependency readiness, degraded mode |
+| W7 | Deployment execution and release controls | Migration command, rollback, health, smoke, evidence |
+| W8 | QA-to-Green consolidation | QA-FD, QA-DEPLOY, PBFAG rows, no placeholder proof |
+
+---
+
+## 4. Evidence Expectations
+
+Later delivery waves must produce evidence for:
+
+- user-visible behavior;
+- API behavior;
+- state changes;
+- audit/provenance events;
+- authority checks;
+- degraded-mode behavior;
+- deployment or preview URL where applicable;
+- test logs;
+- health and smoke checks;
+- rollback or recovery where applicable.
+
+---
+
+## 5. Stage 8 Exit Criteria
+
+Stage 8 can be recommended for CS2 acceptance when:
+
+1. every CS2 condition is mapped to a delivery wave;
+2. the `/alerts` first E2E path is planned;
+3. deployment, QA, dependency, and evidence duties are planned;
+4. Stage 9 inputs are clear;
+5. later stages remain gated until separately authorized.
+
+---
+
+## 6. Boundary
+
+This artifact does not create builder checklist, IAA pre-brief, builder appointment, source code, build evidence, or build work.

--- a/modules/amc/07-implementation-plan/implementation-plan.md
+++ b/modules/amc/07-implementation-plan/implementation-plan.md
@@ -38,7 +38,28 @@ Stage 8 imports:
 
 ---
 
-## 3. Planned Delivery Waves
+## 3. Stage 5a Deployment Inheritance
+
+Stage 8 explicitly inherits the Stage 5a Deployment Execution Strategy at:
+
+`modules/amc/05a-deployment-execution-strategy/deployment-execution-strategy.md` v1.0
+
+The later delivery wave structure must remain consistent with that strategy. No later wave may silently substitute a different deployment or operational model.
+
+| Deployment surface | Stage 8 wave destination | Execution posture |
+|---|---|---|
+| `ci.yml` | W1 and W8 | Automated CI evidence required before later delivery can claim completion |
+| `deploy-frontend.yml` | W1 and W7 | Preview/staging deployment planning required; production execution remains protected/manual where required by governance |
+| `db-migrate.yml` | W7 | Migration command and migration evidence planning required; production database mutation remains protected/manual where required by governance |
+| Secret/environment separation | W1 and W7 | PR, preview, staging, and production secrets must remain separated |
+| Health/smoke validation | W7 and W8 | Health and smoke evidence required before release readiness may be claimed |
+| Rollback/recovery | W7 | Rollback or recovery proof must be planned before release readiness may be claimed |
+
+Stage 9 may not weaken this mapping. Stage 9 must convert it into checklist items only after CS2 accepts Stage 8.
+
+---
+
+## 4. Planned Delivery Waves
 
 | Wave | Scope | Required controls |
 |---|---|---|
@@ -53,7 +74,26 @@ Stage 8 imports:
 
 ---
 
-## 4. Evidence Expectations
+## 5. Red-Test Coverage by Wave
+
+Stage 8 requires each later delivery wave to carry matching red-test coverage. W8 consolidates the proof, but W1-W7 must not proceed without their own planned red-test obligations.
+
+| Wave | Required red-test coverage |
+|---|---|
+| W1 | CI, preview isolation, environment separation, secret boundary, and no production side effect tests |
+| W2 | Auth, tenant isolation, authority middleware, RLS/tenant access, and audit baseline tests |
+| W3 | Core route availability, visible actions, state mutation, audit event, and degraded-mode tests |
+| W4 | First E2E `/alerts` acknowledgement path tests covering UI, API, authority, state, audit, realtime, and visible result |
+| W5 | ARC, approvals, interventions, executive workflow, authority, state, and audit tests |
+| W6 | AIMC, AIMCC, KUC, knowledge, Foreman, specialist, push integration, service-token, dependency readiness, and degraded-mode tests |
+| W7 | Deployment, migration command, rollback, health, smoke, preview/staging, and protected production gate tests |
+| W8 | Cross-wave QA-FD, QA-DEPLOY, PBFAG, tracker/index, and evidence-package consolidation tests |
+
+Stage 9 must preserve this per-wave test map when it creates any later checklist.
+
+---
+
+## 6. Evidence Expectations
 
 Later delivery waves must produce evidence for:
 
@@ -70,18 +110,20 @@ Later delivery waves must produce evidence for:
 
 ---
 
-## 5. Stage 8 Exit Criteria
+## 7. Stage 8 Exit Criteria
 
 Stage 8 can be recommended for CS2 acceptance when:
 
 1. every CS2 condition is mapped to a delivery wave;
 2. the `/alerts` first E2E path is planned;
 3. deployment, QA, dependency, and evidence duties are planned;
-4. Stage 9 inputs are clear;
-5. later stages remain gated until separately authorized.
+4. Stage 5a deployment inheritance is explicit;
+5. red-test coverage is mapped to every later delivery wave;
+6. Stage 9 inputs are clear;
+7. later stages remain gated until separately authorized.
 
 ---
 
-## 6. Boundary
+## 8. Boundary
 
 This artifact does not create builder checklist, IAA pre-brief, builder appointment, source code, build evidence, or build work.

--- a/modules/amc/07-implementation-plan/wave-breakdown.md
+++ b/modules/amc/07-implementation-plan/wave-breakdown.md
@@ -1,17 +1,51 @@
-# Wave Breakdown — Stage 8
+# Wave Breakdown - Stage 8
 
-**Stage**: 8 — Implementation Plan  
+**Stage**: 8 - Implementation Plan  
 **Module**: App Management Centre (AMC)  
-**Status**: ⬜ Not Started
+**Version**: 1.0  
+**Status**: Produced for CS2 review  
+**Issue**: app_management_centre#1199  
+**Wave**: amc-stage8-implementation-plan-20260702
 
 ---
 
-## Purpose
+## 1. Purpose
 
-This document breaks down the AMC build into waves, specifying scope, builder assignments, and sequencing for each wave.
+This file breaks the AMC delivery plan into governed planning waves.
+
+It is not a builder checklist and does not appoint delivery agents.
 
 ---
 
-## Status
+## 2. Wave Summary
 
-Placeholder. Not started.
+| Wave | Name | Summary | Required evidence later |
+|---|---|---|---|
+| W1 | Foundation | Repo, runtime, env, CI, preview, secret boundaries | Env contract, CI proof, preview isolation proof |
+| W2 | Security and Audit Baseline | Auth, tenancy, authority middleware, audit baseline | Authority proof, RLS/tenant proof, audit proof |
+| W3 | Core Surfaces | Material AMC routes and visible actions | Route/action/state/audit/degraded-mode proof |
+| W4 | Alerts E2E | First E2E `/alerts` acknowledgement path | UI/API/authority/state/audit/realtime/visible result proof |
+| W5 | Executive Workflow | ARC, approvals, interventions, workflow surfaces | ARC model proof, workflow state proof, audit proof |
+| W6 | External Integrations | AIMC, AIMCC, KUC, knowledge, Foreman, specialists, push | Service-token proof, dependency readiness, degraded-mode proof |
+| W7 | Deployment Execution | Migration, release gates, rollback, health/smoke | Migration command proof, rollback proof, smoke proof |
+| W8 | QA Evidence | Red-to-green consolidation and evidence package | QA-FD, QA-DEPLOY, PBFAG proof set |
+
+---
+
+## 3. Wave Ordering
+
+W1 and W2 must complete before material user-action work.
+
+W3 establishes the surface map. W4 proves the first full E2E path. W5 and W6 expand the operating surface and integrations. W7 validates deployment controls. W8 consolidates QA evidence.
+
+---
+
+## 4. Stage 9 Inputs
+
+If CS2 later opens Stage 9, the builder checklist must preserve this wave order and must not weaken the required evidence in this file.
+
+---
+
+## 5. Boundary
+
+This wave breakdown does not start build work.

--- a/modules/amc/AMC_PRE_BUILD_ARTIFACT_INDEX.md
+++ b/modules/amc/AMC_PRE_BUILD_ARTIFACT_INDEX.md
@@ -2,7 +2,7 @@
 
 **Module**: App Management Centre (AMC)  
 **Lifecycle Model**: 12-Stage Pre-Build Sequence + Stage 5a (PRE_BUILD_STAGE_MODEL_CANON.md v1.0.0; AMC-GOV-OVERSIGHT-001)  
-**Last Updated**: 2026-07-02 (CS2 decision record for Stages 5, 5a, 6, and 7 prepared for PR review - issue #1197. Stage 8 is eligible to be opened next as a separate governed wave, but has not been started by this record.)  
+**Last Updated**: 2026-07-02 (Stage 8 implementation plan artifacts produced for CS2 review - issue #1199. Stages 9-12 remain blocked.)  
 **Authority**: Maturion Foreman / CS2
 
 ---
@@ -19,7 +19,7 @@ This index catalogs all pre-build artifacts for the AMC module, mapped to their 
 |----------|----------|--------|-------|
 | App Description | `modules/amc/00-app-description/app-description.md` | ✅ Approved Canonical | v1.0, CS2-approved 2026-04-22. Sole authoritative Stage 1 source. Approval ref: #1117. |
 | App Description Approval | `modules/amc/00-app-description/app-description-approval.md` | ✅ Complete | Formal Stage 1 approval record. |
-| Functional Delivery Definition | `modules/amc/00-app-description/functional-delivery-definition.md` | 🟡 Retrofit Reference Input | Produced/merged in PR #1186. Adds fully functional delivery definition. CS2 disposition required as part of retrofit chain. |
+| Functional Delivery Definition | `modules/amc/00-app-description/functional-delivery-definition.md` | 🟡 Retrofit Reference Input | Produced/merged in PR #1186. Adds fully functional delivery definition. |
 | AMC Role Authority & Operating Model | `modules/amc/00-app-description/amc-role-authority-and-operating-model.md` | ⬜ Placeholder | Follow-on work required. Does not block Stage 2. |
 | FM App Description (superseded) | `docs/governance/FM_APP_DESCRIPTION.md` | 📦 Superseded | Retained as historical/provenance reference only. |
 | App Description (root pointer) | `APP_DESCRIPTION.md` | 📌 Reference Only | Follow-on update to point to canonical location pending. |
@@ -32,7 +32,7 @@ This index catalogs all pre-build artifacts for the AMC module, mapped to their 
 |----------|----------|--------|-------|
 | UX Workflow & Wiring Spec | `modules/amc/01-ux-workflow-wiring-spec/ux-workflow-wiring-spec.md` | ✅ Approved Canonical | v1.1, CS2-approved 2026-04-22. |
 | Wiring Artifact Index | `modules/amc/01-ux-workflow-wiring-spec/wiring-artifact-index.md` | ✅ Approved Canonical | v1.0, CS2-approved 2026-04-22. |
-| CTA/API/Data/Audit Contract Matrix | `modules/amc/01-ux-workflow-wiring-spec/cta-api-data-audit-contract-matrix.md` | 🟡 Retrofit Reference Input | Produced/merged in PR #1186. Canonical endpoint/event authority remains with Stage 4 TRS. CS2 disposition required as part of retrofit chain. |
+| CTA/API/Data/Audit Contract Matrix | `modules/amc/01-ux-workflow-wiring-spec/cta-api-data-audit-contract-matrix.md` | 🟡 Retrofit Reference Input | Produced/merged in PR #1186. Canonical endpoint/event authority remains with Stage 4 TRS. |
 
 ---
 
@@ -42,7 +42,7 @@ This index catalogs all pre-build artifacts for the AMC module, mapped to their 
 |----------|----------|--------|-------|
 | Functional Requirements Specification | `modules/amc/02-frs/functional-requirements-specification.md` | ✅ Approved Canonical | v1.1, CS2-approved for Stage 4 progression 2026-04-23. |
 | App Description to FRS Traceability | `modules/amc/02-frs/app-description-to-frs-traceability.md` | ✅ Approved Canonical | v1.0, CS2-approved for Stage 4 progression 2026-04-23. |
-| Functional Delivery Requirements Addendum | `modules/amc/02-frs/functional-delivery-requirements-addendum.md` | 🟡 Retrofit Reference Input | FR-1900 produced/merged in PR #1186. CS2 disposition required as part of retrofit chain. |
+| Functional Delivery Requirements Addendum | `modules/amc/02-frs/functional-delivery-requirements-addendum.md` | 🟡 Retrofit Reference Input | FR-1900 produced/merged in PR #1186. |
 
 ---
 
@@ -52,7 +52,7 @@ This index catalogs all pre-build artifacts for the AMC module, mapped to their 
 |----------|----------|--------|-------|
 | Technical Requirements Specification | `modules/amc/03-trs/technical-requirements-specification.md` | 🟠 Treated as Approved | v1.1, hardened approval-ready 2026-04-23. Formal CS2 approval pending. |
 | FRS to TRS Traceability | `modules/amc/03-trs/frs-to-trs-traceability.md` | 🟠 Treated as Approved | v1.1, hardened 2026-04-23. |
-| Functional Delivery Technical Requirements Addendum | `modules/amc/03-trs/functional-delivery-technical-requirements-addendum.md` | 🟡 Retrofit Reference Input | TR-1900, including TR-1910, produced/merged in PR #1186. CS2 disposition required as part of retrofit chain. |
+| Functional Delivery Technical Requirements Addendum | `modules/amc/03-trs/functional-delivery-technical-requirements-addendum.md` | 🟡 Retrofit Reference Input | TR-1900, including TR-1910, produced/merged in PR #1186. |
 
 ---
 
@@ -60,16 +60,16 @@ This index catalogs all pre-build artifacts for the AMC module, mapped to their 
 
 | Artifact | Location | Status | Notes |
 |----------|----------|--------|-------|
-| Architecture Specification | `modules/amc/04-architecture/architecture-specification.md` | ✅ CS2 Approved with Conditions | v1.0, produced 2026-04-26. Approved by CS2 decision record in issue #1197; Stage 5 retrofit obligations remain binding inputs for Stage 8. |
-| TRS-to-Architecture Traceability | `modules/amc/04-architecture/trs-to-architecture-traceability.md` | ✅ CS2 Approved with Conditions | v1.0, produced 2026-04-26. Approved by CS2 decision record in issue #1197. |
+| Architecture Specification | `modules/amc/04-architecture/architecture-specification.md` | ✅ CS2 Approved with Conditions | Approved by CS2 decision record in issue #1197; Stage 5 retrofit obligations remain binding inputs for Stage 8. |
+| TRS-to-Architecture Traceability | `modules/amc/04-architecture/trs-to-architecture-traceability.md` | ✅ CS2 Approved with Conditions | Approved by CS2 decision record in issue #1197. |
 | Functional Delivery Architecture Addendum | `modules/amc/04-architecture/functional-delivery-architecture-addendum.md` | ✅ CS2 Approved with Conditions | Produced/merged in PR #1188. Binding Stage 8 input. |
-| Functional Delivery Architecture Map | `modules/amc/04-architecture/functional-delivery-architecture-map.md` | ✅ CS2 Approved with Conditions | Produced/merged in PR #1188. Route/action/state/audit/degraded-mode map remains binding for Stage 8. |
-| Stage 5 Functional Delivery Change-Propagation Audit | `modules/amc/04-architecture/stage5-functional-delivery-change-propagation-audit.md` | ✅ CS2 Approved with Conditions | Produced/merged in PR #1188. Conditions carried forward to Stage 8. |
+| Functional Delivery Architecture Map | `modules/amc/04-architecture/functional-delivery-architecture-map.md` | ✅ CS2 Approved with Conditions | Route/action/state/audit/degraded-mode map remains binding for Stage 8. |
+| Stage 5 Functional Delivery Change-Propagation Audit | `modules/amc/04-architecture/stage5-functional-delivery-change-propagation-audit.md` | ✅ CS2 Approved with Conditions | Conditions carried forward to Stage 8. |
 | Stage 5 Review Notes | `modules/amc/04-architecture/stage5-review-notes.md` | ✅ CS2 Approved with Conditions | Produced/merged in PR #1188. |
 | Stage 5 Coverage Note | `modules/amc/04-architecture/extra-review-note.md` | ✅ CS2 Approved with Conditions | Produced/merged in PR #1188. |
 | Architecture (superseded placeholder) | `modules/amc/04-architecture/architecture.md` | ⛔ Superseded | `architecture-specification.md` is the canonical Stage 5 artifact. |
-| Architecture Decision Records | `modules/amc/04-architecture/architecture-decision-records.md` | ⬜ Placeholder | Not started. Create later only if CS2 or Stage 8 requires ADRs. |
-| Architecture Completeness Checklist | `modules/amc/04-architecture/architecture-completeness-checklist.md` | ⬜ Placeholder | Not started / remains a placeholder unless separately populated. |
+| Architecture Decision Records | `modules/amc/04-architecture/architecture-decision-records.md` | ⬜ Placeholder | Not started. |
+| Architecture Completeness Checklist | `modules/amc/04-architecture/architecture-completeness-checklist.md` | ⬜ Placeholder | Not started. |
 
 ---
 
@@ -77,12 +77,12 @@ This index catalogs all pre-build artifacts for the AMC module, mapped to their 
 
 | Artifact | Location | Status | Notes |
 |----------|----------|--------|-------|
-| Deployment Execution Strategy | `modules/amc/05a-deployment-execution-strategy/deployment-execution-strategy.md` | ✅ CS2 Approved with Conditions | v1.0, produced 2026-04-27. Approved by CS2 decision record in issue #1197. |
-| Deployment Surface Ownership Table | `modules/amc/05a-deployment-execution-strategy/deployment-surface-ownership-table.md` | ✅ CS2 Approved with Conditions | v1.0, produced 2026-04-27. Deployment ownership remains binding for Stage 8. |
-| Runner and Environment Constraints | `modules/amc/05a-deployment-execution-strategy/runner-and-environment-constraints.md` | ✅ CS2 Approved with Conditions | v1.0, produced 2026-04-27. Runner and environment constraints remain binding for Stage 8. |
+| Deployment Execution Strategy | `modules/amc/05a-deployment-execution-strategy/deployment-execution-strategy.md` | ✅ CS2 Approved with Conditions | Approved by CS2 decision record in issue #1197. |
+| Deployment Surface Ownership Table | `modules/amc/05a-deployment-execution-strategy/deployment-surface-ownership-table.md` | ✅ CS2 Approved with Conditions | Deployment ownership remains binding for Stage 8. |
+| Runner and Environment Constraints | `modules/amc/05a-deployment-execution-strategy/runner-and-environment-constraints.md` | ✅ CS2 Approved with Conditions | Runner and environment constraints remain binding for Stage 8. |
 | Functional Delivery Deployment Execution Addendum | `modules/amc/05a-deployment-execution-strategy/functional-delivery-deployment-execution-addendum.md` | ✅ CS2 Approved with Conditions | Produced/merged in PR #1190. Binding Stage 8 input. |
-| Deployment Execution Validation Matrix | `modules/amc/05a-deployment-execution-strategy/deployment-execution-validation-matrix.md` | ✅ CS2 Approved with Conditions | Produced/merged in PR #1190. Deployment, CI, preview, secret, migration, rollback, health/smoke, and dependency conditions remain binding for Stage 8. |
-| Stage 5a Functional Delivery Change-Propagation Audit | `modules/amc/05a-deployment-execution-strategy/stage5a-functional-delivery-change-propagation-audit.md` | ✅ CS2 Approved with Conditions | Produced/merged in PR #1190. Conditions carried forward to Stage 8. |
+| Deployment Execution Validation Matrix | `modules/amc/05a-deployment-execution-strategy/deployment-execution-validation-matrix.md` | ✅ CS2 Approved with Conditions | CI, preview, secret, migration, rollback, health/smoke, and dependency conditions remain binding. |
+| Stage 5a Functional Delivery Change-Propagation Audit | `modules/amc/05a-deployment-execution-strategy/stage5a-functional-delivery-change-propagation-audit.md` | ✅ CS2 Approved with Conditions | Conditions carried forward to Stage 8. |
 | Governance Oversight Record | `modules/amc/governance-oversight/DEPLOYMENT_STRATEGY_OVERSIGHT.md` | ✅ Complete | Formal oversight record. CS2 auth: #1133. |
 
 ---
@@ -91,12 +91,12 @@ This index catalogs all pre-build artifacts for the AMC module, mapped to their 
 
 | Artifact | Location | Status | Notes |
 |----------|----------|--------|-------|
-| QA-to-Red Specification | `modules/amc/05-qa-to-red/qa-to-red-specification.md` | ✅ CS2 Approved with Conditions | v1.0, produced 2026-04-27. Approved by CS2 decision record in issue #1197. |
-| Architecture and DES to QA Traceability | `modules/amc/05-qa-to-red/architecture-and-des-to-qa-traceability.md` | ✅ CS2 Approved with Conditions | v1.0, produced 2026-04-27. Must be carried into Stage 8 implementation planning. |
-| Red Test Catalog | `modules/amc/05-qa-to-red/red-test-catalog.md` | ✅ CS2 Approved with Conditions | v1.0, produced 2026-04-27. 79 test cases across 20 families. Retrofit adds QA-FD and QA-DEPLOY families. |
+| QA-to-Red Specification | `modules/amc/05-qa-to-red/qa-to-red-specification.md` | ✅ CS2 Approved with Conditions | Approved by CS2 decision record in issue #1197. |
+| Architecture and DES to QA Traceability | `modules/amc/05-qa-to-red/architecture-and-des-to-qa-traceability.md` | ✅ CS2 Approved with Conditions | Must be carried into Stage 8 planning. |
+| Red Test Catalog | `modules/amc/05-qa-to-red/red-test-catalog.md` | ✅ CS2 Approved with Conditions | Retrofit adds QA-FD and QA-DEPLOY families. |
 | Functional Delivery QA-to-Red Addendum | `modules/amc/05-qa-to-red/functional-delivery-qa-to-red-addendum.md` | ✅ CS2 Approved with Conditions | Produced/merged in PR #1192. Binding Stage 8 input. |
-| Functional Delivery RED Test Expansion Matrix | `modules/amc/05-qa-to-red/functional-delivery-red-test-expansion-matrix.md` | ✅ CS2 Approved with Conditions | Produced/merged in PR #1192. QA-FD and QA-DEPLOY rows remain binding for Stage 8. |
-| Stage 6 Functional Delivery Change-Propagation Audit | `modules/amc/05-qa-to-red/stage6-functional-delivery-change-propagation-audit.md` | ✅ CS2 Approved with Conditions | Produced/merged in PR #1192. Conditions carried forward to Stage 8. |
+| Functional Delivery RED Test Expansion Matrix | `modules/amc/05-qa-to-red/functional-delivery-red-test-expansion-matrix.md` | ✅ CS2 Approved with Conditions | QA-FD and QA-DEPLOY rows remain binding for Stage 8. |
+| Stage 6 Functional Delivery Change-Propagation Audit | `modules/amc/05-qa-to-red/stage6-functional-delivery-change-propagation-audit.md` | ✅ CS2 Approved with Conditions | Conditions carried forward to Stage 8. |
 | QA-to-Red Suite (superseded placeholder) | `modules/amc/05-qa-to-red/qa-to-red-suite.md` | ⛔ Superseded | Placeholder superseded by qa-to-red-specification.md v1.0. |
 | QA Catalog Alignment (superseded placeholder) | `modules/amc/05-qa-to-red/qa-catalog-alignment.md` | ⛔ Superseded | Placeholder superseded by architecture-and-des-to-qa-traceability.md v1.0. |
 
@@ -106,16 +106,17 @@ This index catalogs all pre-build artifacts for the AMC module, mapped to their 
 
 | Artifact | Location | Status | Notes |
 |----------|----------|--------|-------|
-| Pre-Build Final Assurance Gate | `modules/amc/06-pbfag/pre-build-final-assurance-gate.md` | ✅ CS2 Approved with Conditions | Approved by CS2 decision record in issue #1197. Conditions remain binding for Stage 8. |
+| Pre-Build Final Assurance Gate | `modules/amc/06-pbfag/pre-build-final-assurance-gate.md` | ✅ CS2 Approved with Conditions | Conditions remain binding for Stage 8. |
 | PBFAG Evidence Matrix | `modules/amc/06-pbfag/pbfag-evidence-matrix.md` | ✅ CS2 Approved with Conditions | Tracker/index agreement and Stage 8 gate conditions remain binding. |
-| PBFAG Findings and Verdict | `modules/amc/06-pbfag/pbfag-findings-and-verdict.md` | ✅ CS2 Approved with Conditions | Stage 8 may be opened next only as a separate governed wave. |
+| PBFAG Findings and Verdict | `modules/amc/06-pbfag/pbfag-findings-and-verdict.md` | ✅ CS2 Approved with Conditions | Stage 8 opened by issue #1199 only as planning wave. |
 | PBFAG Checklist | `modules/amc/06-pbfag/pbfag-checklist.md` | ✅ CS2 Approved with Conditions | References canonical PBFAG artifacts. |
-| Stage 1-4 Functional Delivery Change-Propagation Audit | `modules/amc/06-pbfag/stage1-4-functional-delivery-change-propagation-audit.md` | ✅ CS2 Approved with Conditions | Produced/merged in PR #1186 chain and retained as upstream input. |
-| Functional Delivery PBFAG Addendum | `modules/amc/06-pbfag/functional-delivery-pbfag-addendum.md` | ✅ CS2 Approved with Conditions | Produced in issue #1193 / PR #1194. Binding Stage 8 input. |
-| PBFAG Retrofit Evidence Matrix | `modules/amc/06-pbfag/pbfag-retrofit-evidence-matrix.md` | ✅ CS2 Approved with Conditions | PBFAG-FD, PBFAG-DEPLOY, PBFAG-QA, PBFAG-TRACK, and PBFAG-STAGE8 rows remain binding for Stage 8. |
+| Stage 1-4 Functional Delivery Change-Propagation Audit | `modules/amc/06-pbfag/stage1-4-functional-delivery-change-propagation-audit.md` | ✅ CS2 Approved with Conditions | Retained as upstream input. |
+| Functional Delivery PBFAG Addendum | `modules/amc/06-pbfag/functional-delivery-pbfag-addendum.md` | ✅ CS2 Approved with Conditions | Binding Stage 8 input. |
+| PBFAG Retrofit Evidence Matrix | `modules/amc/06-pbfag/pbfag-retrofit-evidence-matrix.md` | ✅ CS2 Approved with Conditions | PBFAG-FD, PBFAG-DEPLOY, PBFAG-QA, PBFAG-TRACK, and PBFAG-STAGE8 rows remain binding. |
 | Stage 7 Functional Delivery Change-Propagation Audit | `modules/amc/06-pbfag/stage7-functional-delivery-change-propagation-audit.md` | ✅ CS2 Approved with Conditions | Conditions carried forward to Stage 8. |
-| CS2 Disposition Pack - Stages 5, 5a, 6, and 7 | `modules/amc/06-pbfag/cs2-disposition-pack-stages-5-5a-6-7.md` | ✅ Used for CS2 Decision | Produced in PR #1194. Source for issue #1197 decision record. |
-| CS2 Decision Record - Stages 5, 5a, 6, and 7 | `modules/amc/06-pbfag/cs2-decision-record-stages-5-5a-6-7.md` | ✅ Prepared for CS2 Review | Produced in issue #1197. Records explicit CS2 approval with conditions. Does not authorize implementation or build. |
+| CS2 Disposition Pack - Stages 5, 5a, 6, and 7 | `modules/amc/06-pbfag/cs2-disposition-pack-stages-5-5a-6-7.md` | ✅ Used for CS2 Decision | Source for issue #1197 decision record. |
+| CS2 Decision Record - Stages 5, 5a, 6, and 7 | `modules/amc/06-pbfag/cs2-decision-record-stages-5-5a-6-7.md` | ✅ Current Authority | Explicit CS2 approval with conditions. |
+| Current Authority Note - Stages 5, 5a, 6, and 7 | `modules/amc/06-pbfag/current-authority-note-stages-5-5a-6-7.md` | ✅ Current Authority Note | Clarifies current status source. |
 
 ---
 
@@ -123,8 +124,9 @@ This index catalogs all pre-build artifacts for the AMC module, mapped to their 
 
 | Artifact | Location | Status | Notes |
 |----------|----------|--------|-------|
-| Implementation Plan | `modules/amc/07-implementation-plan/implementation-plan.md` | ⬜ Placeholder | Not started. Eligible to be opened next only by separate Stage 8 issue/PR. |
-| Wave Breakdown | `modules/amc/07-implementation-plan/wave-breakdown.md` | ⬜ Placeholder | Not started. |
+| Implementation Plan | `modules/amc/07-implementation-plan/implementation-plan.md` | 🟡 Produced for CS2 Review | Produced in issue #1199. Planning artifact only. |
+| Wave Breakdown | `modules/amc/07-implementation-plan/wave-breakdown.md` | 🟡 Produced for CS2 Review | Produced in issue #1199. Planning artifact only. |
+| Condition Import Matrix | `modules/amc/07-implementation-plan/condition-import-matrix.md` | 🟡 Produced for CS2 Review | Maps CS2 conditions into Stage 8 planning waves. |
 
 ---
 

--- a/modules/amc/BUILD_PROGRESS_TRACKER.md
+++ b/modules/amc/BUILD_PROGRESS_TRACKER.md
@@ -3,13 +3,13 @@
 **Module**: App Management Centre (AMC)  
 **Module Slug**: AMC  
 **Last Updated**: 2026-07-02  
-**Updated By**: foreman-v2-agent (wave: amc-cs2-disposition-stages-5-7 - issue #1197; PR #1198; CS2 decision record for Stages 5, 5a, 6, and 7 prepared. Stage 8 is eligible to be opened next as a separate governed wave, but this PR does not start Stage 8.)
+**Updated By**: foreman-v2-agent (wave: amc-stage8-implementation-plan-20260702 - issue #1199; Stage 8 implementation plan artifacts produced for CS2 review. Stages 9-12 remain blocked.)
 
 > **Classification**: ACTIVE  
 > **Document Role**: PRIMARY LIVE CONTROL DOCUMENT - CS2 should use this document as the main live progress dashboard.  
 > **Canon Reference**: `PRE_BUILD_STAGE_MODEL_CANON.md` v1.0.0 plus current ISMS/MMM functional-delivery retrofit lessons  
-> **Current Issue**: [app_management_centre#1197](https://github.com/APGI-cmy/app_management_centre/issues/1197)  
-> **Current PR**: [app_management_centre#1198](https://github.com/APGI-cmy/app_management_centre/pull/1198)  
+> **Current Issue**: [app_management_centre#1199](https://github.com/APGI-cmy/app_management_centre/issues/1199)  
+> **Current PR**: pending Stage 8 PR creation  
 > **Update Rule**: This document MUST be updated immediately after every AMC stage issue, wave completion, approval, or readiness/blocker change. Stale tracker text is a governance defect.
 
 ## Retrofit and Disposition Notes
@@ -19,7 +19,8 @@
 - PR #1190 merged Stage 5a deployment-execution retrofit reference inputs.
 - PR #1192 merged Stage 6 QA-to-Red retrofit reference inputs.
 - PR #1194 merged Stage 7 PBFAG retrofit artifacts and `cs2-disposition-pack-stages-5-5a-6-7.md`.
-- Issue #1197 / PR #1198 records the explicit CS2 decision approving Stages 5, 5a, 6, and 7 with conditions.
+- PR #1198 recorded explicit CS2 approval with conditions for Stages 5, 5a, 6, and 7.
+- Issue #1199 opens Stage 8 implementation planning only.
 
 ---
 
@@ -35,32 +36,29 @@
 | 5a | Deployment Execution Strategy | ✅ CS2 APPROVED WITH CONDITIONS | Deployment validation, CI, preview, secret, migration, rollback, health/smoke, and dependency conditions remain binding inputs for Stage 8. |
 | 6 | QA-to-Red | ✅ CS2 APPROVED WITH CONDITIONS | QA-FD and QA-DEPLOY rows remain binding inputs for Stage 8 and later QA-to-Green evidence. |
 | **7** | **PBFAG** | **✅ CS2 APPROVED WITH CONDITIONS** | PBFAG-FD, PBFAG-DEPLOY, PBFAG-QA, tracker/index, and Stage 8 block rows remain binding inputs for Stage 8. |
-| 8 | Implementation Plan | ⬜ Not Started — 🟡 ELIGIBLE NEXT | May be opened only by a separate Stage 8 issue/PR that imports the CS2 decision record and all conditions. |
-| 9 | Builder Checklist | ⬜ Not Started — 🔴 BLOCKED | Blocked until Stage 8 is authorized and complete. |
+| **8** | **Implementation Plan** | **🟡 IN PROGRESS — Produced for CS2 Review** | Issue #1199 produces implementation-plan artifacts only. No builder checklist, IAA pre-brief, builder appointment, code, build evidence, or build work. |
+| 9 | Builder Checklist | ⬜ Not Started — 🔴 BLOCKED | Blocked until Stage 8 is CS2-accepted and Stage 9 is separately authorized. |
 | 10 | IAA Pre-Brief | ⬜ Not Started — 🔴 BLOCKED | Blocked until canonical sequence authorizes it. |
 | 11 | Builder Appointment | ⬜ Not Started — 🔴 BLOCKED | No builders appointed. |
-| 12 | Build | ⬜ Not Started — 🔴 BLOCKED | No implementation/build authorization. |
+| 12 | Build | ⬜ Not Started — 🔴 BLOCKED | No build authorization. |
 
 ---
 
-## CS2 Disposition Record
+## Stage 8 Artifacts
 
-**Status**: Prepared for PR review  
-**Location**: `modules/amc/06-pbfag/cs2-decision-record-stages-5-5a-6-7.md`
+**Status**: Produced for CS2 review  
+**Location**: `modules/amc/07-implementation-plan/`
 
-**Decision summary**:
-- Stage 5 Architecture: approved with conditions.
-- Stage 5a Deployment Execution Strategy: approved with conditions.
-- Stage 6 QA-to-Red: approved with conditions.
-- Stage 7 PBFAG: approved with conditions.
-
-**Boundary**: This tracker update does not start Stage 8, does not create implementation work, does not appoint builders, and does not authorize build.
+Artifacts:
+- `implementation-plan.md`
+- `wave-breakdown.md`
+- `condition-import-matrix.md`
 
 ---
 
-## Stage 8 Eligibility Conditions
+## Stage 8 Conditions Imported
 
-Any later Stage 8 issue and implementation plan must import:
+The Stage 8 package imports:
 
 1. `cs2-decision-record-stages-5-5a-6-7.md`.
 2. Stage 5 route/action/state/audit/degraded-mode map.
@@ -71,10 +69,10 @@ Any later Stage 8 issue and implementation plan must import:
 7. Placeholder/stub rejection rule.
 8. Production approval gates and secret separation.
 9. Supabase migration command freeze.
-10. Rollback evidence planning.
-11. Runtime health/smoke validation.
-12. External dependency readiness and visible degraded-mode behavior.
-13. Complete implementation evidence package.
+10. Rollback planning.
+11. Runtime health and smoke validation.
+12. Dependency readiness and visible degraded-mode behavior.
+13. Complete delivery evidence package.
 
 ---
 
@@ -89,19 +87,17 @@ Any later Stage 8 issue and implementation plan must import:
 
 ## Next Action
 
-1. Review and merge the CS2 disposition record PR for issue #1197.
-2. After merge, Stage 8 may be opened as a separate governed Stage 8 implementation-planning wave.
-3. Do not create builder checklist, IAA pre-brief, builder appointment, or build work from this PR.
+1. Review Stage 8 PR for issue #1199.
+2. Do not open Stage 9 until Stage 8 is CS2-accepted.
+3. Do not create IAA pre-brief, builder appointment, or build work from this PR.
 
 ---
 
 ## References
 
 - [PRE_BUILD_STAGE_MODEL_CANON.md](../../governance/canon/PRE_BUILD_STAGE_MODEL_CANON.md)
-- [cs2-disposition-pack-stages-5-5a-6-7.md](./06-pbfag/cs2-disposition-pack-stages-5-5a-6-7.md)
 - [cs2-decision-record-stages-5-5a-6-7.md](./06-pbfag/cs2-decision-record-stages-5-5a-6-7.md)
-- [functional-delivery-architecture-map.md](./04-architecture/functional-delivery-architecture-map.md)
-- [deployment-execution-validation-matrix.md](./05a-deployment-execution-strategy/deployment-execution-validation-matrix.md)
-- [functional-delivery-red-test-expansion-matrix.md](./05-qa-to-red/functional-delivery-red-test-expansion-matrix.md)
-- [pbfag-retrofit-evidence-matrix.md](./06-pbfag/pbfag-retrofit-evidence-matrix.md)
+- [condition-import-matrix.md](./07-implementation-plan/condition-import-matrix.md)
+- [implementation-plan.md](./07-implementation-plan/implementation-plan.md)
+- [wave-breakdown.md](./07-implementation-plan/wave-breakdown.md)
 - [AMC_PRE_BUILD_ARTIFACT_INDEX.md](./AMC_PRE_BUILD_ARTIFACT_INDEX.md)

--- a/modules/amc/BUILD_PROGRESS_TRACKER.md
+++ b/modules/amc/BUILD_PROGRESS_TRACKER.md
@@ -3,13 +3,13 @@
 **Module**: App Management Centre (AMC)  
 **Module Slug**: AMC  
 **Last Updated**: 2026-07-02  
-**Updated By**: foreman-v2-agent (wave: amc-stage8-implementation-plan-20260702 - issue #1199; Stage 8 implementation plan artifacts produced for CS2 review. Stages 9-12 remain blocked.)
+**Updated By**: foreman-v2-agent (wave: amc-stage8-implementation-plan-20260702 - issue #1199; PR #1200; Stage 8 implementation plan artifacts produced for CS2 review. Stages 9-12 remain blocked.)
 
 > **Classification**: ACTIVE  
 > **Document Role**: PRIMARY LIVE CONTROL DOCUMENT - CS2 should use this document as the main live progress dashboard.  
 > **Canon Reference**: `PRE_BUILD_STAGE_MODEL_CANON.md` v1.0.0 plus current ISMS/MMM functional-delivery retrofit lessons  
 > **Current Issue**: [app_management_centre#1199](https://github.com/APGI-cmy/app_management_centre/issues/1199)  
-> **Current PR**: pending Stage 8 PR creation  
+> **Current PR**: [app_management_centre#1200](https://github.com/APGI-cmy/app_management_centre/pull/1200)  
 > **Update Rule**: This document MUST be updated immediately after every AMC stage issue, wave completion, approval, or readiness/blocker change. Stale tracker text is a governance defect.
 
 ## Retrofit and Disposition Notes
@@ -20,7 +20,7 @@
 - PR #1192 merged Stage 6 QA-to-Red retrofit reference inputs.
 - PR #1194 merged Stage 7 PBFAG retrofit artifacts and `cs2-disposition-pack-stages-5-5a-6-7.md`.
 - PR #1198 recorded explicit CS2 approval with conditions for Stages 5, 5a, 6, and 7.
-- Issue #1199 opens Stage 8 implementation planning only.
+- Issue #1199 / PR #1200 opens Stage 8 implementation planning only.
 
 ---
 
@@ -36,7 +36,7 @@
 | 5a | Deployment Execution Strategy | ✅ CS2 APPROVED WITH CONDITIONS | Deployment validation, CI, preview, secret, migration, rollback, health/smoke, and dependency conditions remain binding inputs for Stage 8. |
 | 6 | QA-to-Red | ✅ CS2 APPROVED WITH CONDITIONS | QA-FD and QA-DEPLOY rows remain binding inputs for Stage 8 and later QA-to-Green evidence. |
 | **7** | **PBFAG** | **✅ CS2 APPROVED WITH CONDITIONS** | PBFAG-FD, PBFAG-DEPLOY, PBFAG-QA, tracker/index, and Stage 8 block rows remain binding inputs for Stage 8. |
-| **8** | **Implementation Plan** | **🟡 IN PROGRESS — Produced for CS2 Review** | Issue #1199 produces implementation-plan artifacts only. No builder checklist, IAA pre-brief, builder appointment, code, build evidence, or build work. |
+| **8** | **Implementation Plan** | **🟡 IN PROGRESS — Produced for CS2 Review** | Issue #1199 / PR #1200 produces implementation-plan artifacts only. No builder checklist, IAA pre-brief, builder appointment, code, build evidence, or build work. |
 | 9 | Builder Checklist | ⬜ Not Started — 🔴 BLOCKED | Blocked until Stage 8 is CS2-accepted and Stage 9 is separately authorized. |
 | 10 | IAA Pre-Brief | ⬜ Not Started — 🔴 BLOCKED | Blocked until canonical sequence authorizes it. |
 | 11 | Builder Appointment | ⬜ Not Started — 🔴 BLOCKED | No builders appointed. |


### PR DESCRIPTION
## Summary

governing_issue: #1199

This PR opens the AMC Stage 8 Implementation Plan wave after PR #1198 recorded explicit CS2 approval with conditions for Stages 5, 5a, 6, and 7.

## Added / updated artifacts

1. `modules/amc/07-implementation-plan/implementation-plan.md`
   - Produces the Stage 8 implementation plan for CS2 review.
   - Imports the Stage 5, 5a, 6, and 7 conditions.

2. `modules/amc/07-implementation-plan/wave-breakdown.md`
   - Defines the Stage 8 delivery-planning wave structure.

3. `modules/amc/07-implementation-plan/condition-import-matrix.md`
   - Maps approved conditions into Stage 8 planning waves.

4. `modules/amc/BUILD_PROGRESS_TRACKER.md`
   - Updates Stage 8 to in progress / produced for CS2 review.
   - Keeps Stages 9-12 blocked.

5. `modules/amc/AMC_PRE_BUILD_ARTIFACT_INDEX.md`
   - Indexes the Stage 8 artifacts.
   - Keeps later-stage artifacts as placeholders.

6. `.agent-admin/wave-records/amc-wave-record-1199-current.md`
   - Adds a safe wave record for issue #1199.

## Governance boundary

This PR does not create builder checklist, IAA pre-brief, builder appointment, source code, build evidence, build-readiness certification, or build work.

## Stage posture

Stage 8 is produced for CS2 review only. Stage 9 may not open until Stage 8 is explicitly accepted and a separate Stage 9 wave is authorized.

Closes #1199.