### PR TITLE
AMC: CS2 disposition record for Stage 8 implementation plan

### DIFF
--- a/.agent-admin/wave-records/amc-wave-record-1201-current.md
+++ b/.agent-admin/wave-records/amc-wave-record-1201-current.md
@@ -3,7 +3,7 @@
 PR: #1202
 Issue: #1201
 Wave: amc-stage8-cs2-disposition
-Reviewed SHA: d5606d06c8eaf3bb24fb13f1233786fa7dc80d13
+Reviewed SHA: f8fb9559cccec03e194ec15c543a40d17c19898a
 Verdict: PASS
 PHASE_B_BLOCKING_TOKEN: IAA-session-1201-20260707-PASS
 ecap_waiver_ref: stage8-disposition-1201-20260707
@@ -19,6 +19,6 @@ This record is limited to disposition, tracker, and index documentation.
 
 delta_assurance_verdict: PASS
 base_head: 7a0040b5b275e776dfc87182a862b45ebc96e1f4
-final_head: d5606d06c8eaf3bb24fb13f1233786fa7dc80d13
+final_head: f8fb9559cccec03e194ec15c543a40d17c19898a
 delta_classification: token-recording-only
 final_token_binding: IAA-session-1201-20260707-PASS

--- a/.agent-admin/wave-records/amc-wave-record-1201-current.md
+++ b/.agent-admin/wave-records/amc-wave-record-1201-current.md
@@ -1,8 +1,9 @@
-# AMC Wave Record Current - Issue 1201
+# AMC Wave Record Current - PR 1202
 
+PR: #1202
 Issue: #1201
 Wave: amc-stage8-cs2-disposition
-Reviewed SHA: 011c5df3a8b604da79d0384da5b651106cc52b2a
+Reviewed SHA: d5606d06c8eaf3bb24fb13f1233786fa7dc80d13
 Verdict: PASS
 PHASE_B_BLOCKING_TOKEN: IAA-session-1201-20260707-PASS
 ecap_waiver_ref: stage8-disposition-1201-20260707
@@ -12,12 +13,12 @@ Reviewed files:
 - modules/amc/BUILD_PROGRESS_TRACKER.md
 - modules/amc/AMC_PRE_BUILD_ARTIFACT_INDEX.md
 
-This record supports AMC Stage 8 disposition for issue #1201.
+This record supports AMC Stage 8 disposition for issue #1201 and PR #1202.
 
 This record is limited to disposition, tracker, and index documentation.
 
 delta_assurance_verdict: PASS
 base_head: 7a0040b5b275e776dfc87182a862b45ebc96e1f4
-final_head: 011c5df3a8b604da79d0384da5b651106cc52b2a
-delta_classification: protected-path-docs-only
+final_head: d5606d06c8eaf3bb24fb13f1233786fa7dc80d13
+delta_classification: token-recording-only
 final_token_binding: IAA-session-1201-20260707-PASS

--- a/.agent-admin/wave-records/amc-wave-record-1201-current.md
+++ b/.agent-admin/wave-records/amc-wave-record-1201-current.md
@@ -1,0 +1,23 @@
+# AMC Wave Record Current - Issue 1201
+
+Issue: #1201
+Wave: amc-stage8-cs2-disposition
+Reviewed SHA: 011c5df3a8b604da79d0384da5b651106cc52b2a
+Verdict: PASS
+PHASE_B_BLOCKING_TOKEN: IAA-session-1201-20260707-PASS
+ecap_waiver_ref: stage8-disposition-1201-20260707
+
+Reviewed files:
+- modules/amc/07-implementation-plan/cs2-decision-record-stage-8.md
+- modules/amc/BUILD_PROGRESS_TRACKER.md
+- modules/amc/AMC_PRE_BUILD_ARTIFACT_INDEX.md
+
+This record supports AMC Stage 8 disposition for issue #1201.
+
+This record is limited to disposition, tracker, and index documentation.
+
+delta_assurance_verdict: PASS
+base_head: 7a0040b5b275e776dfc87182a862b45ebc96e1f4
+final_head: 011c5df3a8b604da79d0384da5b651106cc52b2a
+delta_classification: protected-path-docs-only
+final_token_binding: IAA-session-1201-20260707-PASS

--- a/modules/amc/07-implementation-plan/cs2-decision-record-stage-8.md
+++ b/modules/amc/07-implementation-plan/cs2-decision-record-stage-8.md
@@ -1,0 +1,89 @@
+# CS2 Decision Record - Stage 8 Implementation Plan
+
+**Module**: App Management Centre (AMC)  
+**Stage**: 8 - Implementation Plan  
+**Issue**: app_management_centre#1201  
+**Related PR**: app_management_centre#1200  
+**Decision Date**: 2026-07-07  
+**Decision Authority**: CS2  
+**Status**: Approved with Conditions
+
+---
+
+## 1. Purpose
+
+This record captures CS2 disposition of the AMC Stage 8 Implementation Plan after PR #1200 merged.
+
+This record is a disposition artifact only. It does not create Stage 9 builder checklist, IAA pre-brief, builder appointment, source code, build evidence, build-readiness certification, or build work.
+
+---
+
+## 2. Reviewed Stage 8 Artifacts
+
+CS2 disposition is based on the following Stage 8 artifacts:
+
+1. `modules/amc/07-implementation-plan/implementation-plan.md`.
+2. `modules/amc/07-implementation-plan/wave-breakdown.md`.
+3. `modules/amc/07-implementation-plan/condition-import-matrix.md`.
+4. `modules/amc/BUILD_PROGRESS_TRACKER.md`.
+5. `modules/amc/AMC_PRE_BUILD_ARTIFACT_INDEX.md`.
+
+---
+
+## 3. Decision
+
+CS2 approves Stage 8 Implementation Plan with conditions.
+
+Stage 8 is accepted as a planning-stage artifact set. It may be used as the authority input for a later Stage 9 Builder Checklist wave.
+
+Stage 9 is eligible next only after this disposition record is merged, and only through a separate governed issue and pull request.
+
+---
+
+## 4. Conditions Carried into Stage 9
+
+Any later Stage 9 wave must import and preserve:
+
+1. The Stage 8 implementation plan.
+2. The Stage 8 wave breakdown.
+3. The Stage 8 condition-import matrix.
+4. Stage 5 route/action/state/audit/degraded-mode obligations.
+5. Stage 5a deployment inheritance, including `ci.yml`, `deploy-frontend.yml`, and `db-migrate.yml` surface planning.
+6. Secret and environment separation.
+7. Production approval gates and protected/manual surfaces.
+8. Migration command and migration evidence planning.
+9. Rollback or recovery proof requirements.
+10. Runtime health and smoke validation.
+11. Dependency readiness and visible degraded-mode behavior.
+12. Per-wave red-test coverage for W1 through W8.
+13. First E2E `/alerts` acknowledgement path.
+14. Complete implementation evidence package requirements.
+15. Placeholder, stub, skipped, todo, and trivial-proof rejection.
+
+---
+
+## 5. Stage 9 Eligibility
+
+After this disposition PR merges, Stage 9 may be opened as a separate governed Builder Checklist wave.
+
+Stage 9 must remain checklist-only until its own approval boundary is satisfied.
+
+---
+
+## 6. Explicit Non-Scope
+
+This record does not:
+
+- create Stage 9 builder checklist;
+- create IAA pre-brief;
+- appoint builders;
+- create implementation code;
+- create build evidence;
+- certify build readiness;
+- start build.
+
+---
+
+## 7. Disposition Statement
+
+Stage 8 Implementation Plan is approved with conditions and is suitable to serve as the planning authority for the next governed stage.

--- a/modules/amc/AMC_PRE_BUILD_ARTIFACT_INDEX.md
+++ b/modules/amc/AMC_PRE_BUILD_ARTIFACT_INDEX.md
@@ -2,7 +2,7 @@
 
 **Module**: App Management Centre (AMC)  
 **Lifecycle Model**: 12-Stage Pre-Build Sequence + Stage 5a (PRE_BUILD_STAGE_MODEL_CANON.md v1.0.0; AMC-GOV-OVERSIGHT-001)  
-**Last Updated**: 2026-07-02 (Stage 8 implementation plan artifacts produced for CS2 review - issue #1199. Stages 9-12 remain blocked.)  
+**Last Updated**: 2026-07-07 (Stage 8 CS2 disposition record prepared for PR review - issue #1201. Stage 9 becomes eligible next only after this disposition PR is merged as a separate governed wave.)  
 **Authority**: Maturion Foreman / CS2
 
 ---
@@ -60,11 +60,11 @@ This index catalogs all pre-build artifacts for the AMC module, mapped to their 
 
 | Artifact | Location | Status | Notes |
 |----------|----------|--------|-------|
-| Architecture Specification | `modules/amc/04-architecture/architecture-specification.md` | ✅ CS2 Approved with Conditions | Approved by CS2 decision record in issue #1197; Stage 5 retrofit obligations remain binding inputs for Stage 8. |
+| Architecture Specification | `modules/amc/04-architecture/architecture-specification.md` | ✅ CS2 Approved with Conditions | Approved by CS2 decision record in issue #1197; Stage 5 retrofit obligations remain binding inputs. |
 | TRS-to-Architecture Traceability | `modules/amc/04-architecture/trs-to-architecture-traceability.md` | ✅ CS2 Approved with Conditions | Approved by CS2 decision record in issue #1197. |
-| Functional Delivery Architecture Addendum | `modules/amc/04-architecture/functional-delivery-architecture-addendum.md` | ✅ CS2 Approved with Conditions | Produced/merged in PR #1188. Binding Stage 8 input. |
-| Functional Delivery Architecture Map | `modules/amc/04-architecture/functional-delivery-architecture-map.md` | ✅ CS2 Approved with Conditions | Route/action/state/audit/degraded-mode map remains binding for Stage 8. |
-| Stage 5 Functional Delivery Change-Propagation Audit | `modules/amc/04-architecture/stage5-functional-delivery-change-propagation-audit.md` | ✅ CS2 Approved with Conditions | Conditions carried forward to Stage 8. |
+| Functional Delivery Architecture Addendum | `modules/amc/04-architecture/functional-delivery-architecture-addendum.md` | ✅ CS2 Approved with Conditions | Produced/merged in PR #1188. Binding downstream input. |
+| Functional Delivery Architecture Map | `modules/amc/04-architecture/functional-delivery-architecture-map.md` | ✅ CS2 Approved with Conditions | Route/action/state/audit/degraded-mode map remains binding. |
+| Stage 5 Functional Delivery Change-Propagation Audit | `modules/amc/04-architecture/stage5-functional-delivery-change-propagation-audit.md` | ✅ CS2 Approved with Conditions | Conditions carried forward. |
 | Stage 5 Review Notes | `modules/amc/04-architecture/stage5-review-notes.md` | ✅ CS2 Approved with Conditions | Produced/merged in PR #1188. |
 | Stage 5 Coverage Note | `modules/amc/04-architecture/extra-review-note.md` | ✅ CS2 Approved with Conditions | Produced/merged in PR #1188. |
 | Architecture (superseded placeholder) | `modules/amc/04-architecture/architecture.md` | ⛔ Superseded | `architecture-specification.md` is the canonical Stage 5 artifact. |
@@ -78,11 +78,11 @@ This index catalogs all pre-build artifacts for the AMC module, mapped to their 
 | Artifact | Location | Status | Notes |
 |----------|----------|--------|-------|
 | Deployment Execution Strategy | `modules/amc/05a-deployment-execution-strategy/deployment-execution-strategy.md` | ✅ CS2 Approved with Conditions | Approved by CS2 decision record in issue #1197. |
-| Deployment Surface Ownership Table | `modules/amc/05a-deployment-execution-strategy/deployment-surface-ownership-table.md` | ✅ CS2 Approved with Conditions | Deployment ownership remains binding for Stage 8. |
-| Runner and Environment Constraints | `modules/amc/05a-deployment-execution-strategy/runner-and-environment-constraints.md` | ✅ CS2 Approved with Conditions | Runner and environment constraints remain binding for Stage 8. |
-| Functional Delivery Deployment Execution Addendum | `modules/amc/05a-deployment-execution-strategy/functional-delivery-deployment-execution-addendum.md` | ✅ CS2 Approved with Conditions | Produced/merged in PR #1190. Binding Stage 8 input. |
+| Deployment Surface Ownership Table | `modules/amc/05a-deployment-execution-strategy/deployment-surface-ownership-table.md` | ✅ CS2 Approved with Conditions | Deployment ownership remains binding. |
+| Runner and Environment Constraints | `modules/amc/05a-deployment-execution-strategy/runner-and-environment-constraints.md` | ✅ CS2 Approved with Conditions | Runner and environment constraints remain binding. |
+| Functional Delivery Deployment Execution Addendum | `modules/amc/05a-deployment-execution-strategy/functional-delivery-deployment-execution-addendum.md` | ✅ CS2 Approved with Conditions | Produced/merged in PR #1190. Binding downstream input. |
 | Deployment Execution Validation Matrix | `modules/amc/05a-deployment-execution-strategy/deployment-execution-validation-matrix.md` | ✅ CS2 Approved with Conditions | CI, preview, secret, migration, rollback, health/smoke, and dependency conditions remain binding. |
-| Stage 5a Functional Delivery Change-Propagation Audit | `modules/amc/05a-deployment-execution-strategy/stage5a-functional-delivery-change-propagation-audit.md` | ✅ CS2 Approved with Conditions | Conditions carried forward to Stage 8. |
+| Stage 5a Functional Delivery Change-Propagation Audit | `modules/amc/05a-deployment-execution-strategy/stage5a-functional-delivery-change-propagation-audit.md` | ✅ CS2 Approved with Conditions | Conditions carried forward. |
 | Governance Oversight Record | `modules/amc/governance-oversight/DEPLOYMENT_STRATEGY_OVERSIGHT.md` | ✅ Complete | Formal oversight record. CS2 auth: #1133. |
 
 ---
@@ -92,11 +92,11 @@ This index catalogs all pre-build artifacts for the AMC module, mapped to their 
 | Artifact | Location | Status | Notes |
 |----------|----------|--------|-------|
 | QA-to-Red Specification | `modules/amc/05-qa-to-red/qa-to-red-specification.md` | ✅ CS2 Approved with Conditions | Approved by CS2 decision record in issue #1197. |
-| Architecture and DES to QA Traceability | `modules/amc/05-qa-to-red/architecture-and-des-to-qa-traceability.md` | ✅ CS2 Approved with Conditions | Must be carried into Stage 8 planning. |
+| Architecture and DES to QA Traceability | `modules/amc/05-qa-to-red/architecture-and-des-to-qa-traceability.md` | ✅ CS2 Approved with Conditions | Must be carried downstream. |
 | Red Test Catalog | `modules/amc/05-qa-to-red/red-test-catalog.md` | ✅ CS2 Approved with Conditions | Retrofit adds QA-FD and QA-DEPLOY families. |
-| Functional Delivery QA-to-Red Addendum | `modules/amc/05-qa-to-red/functional-delivery-qa-to-red-addendum.md` | ✅ CS2 Approved with Conditions | Produced/merged in PR #1192. Binding Stage 8 input. |
-| Functional Delivery RED Test Expansion Matrix | `modules/amc/05-qa-to-red/functional-delivery-red-test-expansion-matrix.md` | ✅ CS2 Approved with Conditions | QA-FD and QA-DEPLOY rows remain binding for Stage 8. |
-| Stage 6 Functional Delivery Change-Propagation Audit | `modules/amc/05-qa-to-red/stage6-functional-delivery-change-propagation-audit.md` | ✅ CS2 Approved with Conditions | Conditions carried forward to Stage 8. |
+| Functional Delivery QA-to-Red Addendum | `modules/amc/05-qa-to-red/functional-delivery-qa-to-red-addendum.md` | ✅ CS2 Approved with Conditions | Produced/merged in PR #1192. Binding downstream input. |
+| Functional Delivery RED Test Expansion Matrix | `modules/amc/05-qa-to-red/functional-delivery-red-test-expansion-matrix.md` | ✅ CS2 Approved with Conditions | QA-FD and QA-DEPLOY rows remain binding. |
+| Stage 6 Functional Delivery Change-Propagation Audit | `modules/amc/05-qa-to-red/stage6-functional-delivery-change-propagation-audit.md` | ✅ CS2 Approved with Conditions | Conditions carried forward. |
 | QA-to-Red Suite (superseded placeholder) | `modules/amc/05-qa-to-red/qa-to-red-suite.md` | ⛔ Superseded | Placeholder superseded by qa-to-red-specification.md v1.0. |
 | QA Catalog Alignment (superseded placeholder) | `modules/amc/05-qa-to-red/qa-catalog-alignment.md` | ⛔ Superseded | Placeholder superseded by architecture-and-des-to-qa-traceability.md v1.0. |
 
@@ -106,14 +106,14 @@ This index catalogs all pre-build artifacts for the AMC module, mapped to their 
 
 | Artifact | Location | Status | Notes |
 |----------|----------|--------|-------|
-| Pre-Build Final Assurance Gate | `modules/amc/06-pbfag/pre-build-final-assurance-gate.md` | ✅ CS2 Approved with Conditions | Conditions remain binding for Stage 8. |
+| Pre-Build Final Assurance Gate | `modules/amc/06-pbfag/pre-build-final-assurance-gate.md` | ✅ CS2 Approved with Conditions | Conditions remain binding. |
 | PBFAG Evidence Matrix | `modules/amc/06-pbfag/pbfag-evidence-matrix.md` | ✅ CS2 Approved with Conditions | Tracker/index agreement and Stage 8 gate conditions remain binding. |
 | PBFAG Findings and Verdict | `modules/amc/06-pbfag/pbfag-findings-and-verdict.md` | ✅ CS2 Approved with Conditions | Stage 8 opened by issue #1199 only as planning wave. |
 | PBFAG Checklist | `modules/amc/06-pbfag/pbfag-checklist.md` | ✅ CS2 Approved with Conditions | References canonical PBFAG artifacts. |
 | Stage 1-4 Functional Delivery Change-Propagation Audit | `modules/amc/06-pbfag/stage1-4-functional-delivery-change-propagation-audit.md` | ✅ CS2 Approved with Conditions | Retained as upstream input. |
-| Functional Delivery PBFAG Addendum | `modules/amc/06-pbfag/functional-delivery-pbfag-addendum.md` | ✅ CS2 Approved with Conditions | Binding Stage 8 input. |
+| Functional Delivery PBFAG Addendum | `modules/amc/06-pbfag/functional-delivery-pbfag-addendum.md` | ✅ CS2 Approved with Conditions | Binding downstream input. |
 | PBFAG Retrofit Evidence Matrix | `modules/amc/06-pbfag/pbfag-retrofit-evidence-matrix.md` | ✅ CS2 Approved with Conditions | PBFAG-FD, PBFAG-DEPLOY, PBFAG-QA, PBFAG-TRACK, and PBFAG-STAGE8 rows remain binding. |
-| Stage 7 Functional Delivery Change-Propagation Audit | `modules/amc/06-pbfag/stage7-functional-delivery-change-propagation-audit.md` | ✅ CS2 Approved with Conditions | Conditions carried forward to Stage 8. |
+| Stage 7 Functional Delivery Change-Propagation Audit | `modules/amc/06-pbfag/stage7-functional-delivery-change-propagation-audit.md` | ✅ CS2 Approved with Conditions | Conditions carried forward. |
 | CS2 Disposition Pack - Stages 5, 5a, 6, and 7 | `modules/amc/06-pbfag/cs2-disposition-pack-stages-5-5a-6-7.md` | ✅ Used for CS2 Decision | Source for issue #1197 decision record. |
 | CS2 Decision Record - Stages 5, 5a, 6, and 7 | `modules/amc/06-pbfag/cs2-decision-record-stages-5-5a-6-7.md` | ✅ Current Authority | Explicit CS2 approval with conditions. |
 | Current Authority Note - Stages 5, 5a, 6, and 7 | `modules/amc/06-pbfag/current-authority-note-stages-5-5a-6-7.md` | ✅ Current Authority Note | Clarifies current status source. |
@@ -124,9 +124,10 @@ This index catalogs all pre-build artifacts for the AMC module, mapped to their 
 
 | Artifact | Location | Status | Notes |
 |----------|----------|--------|-------|
-| Implementation Plan | `modules/amc/07-implementation-plan/implementation-plan.md` | 🟡 Produced for CS2 Review | Produced in issue #1199. Planning artifact only. |
-| Wave Breakdown | `modules/amc/07-implementation-plan/wave-breakdown.md` | 🟡 Produced for CS2 Review | Produced in issue #1199. Planning artifact only. |
-| Condition Import Matrix | `modules/amc/07-implementation-plan/condition-import-matrix.md` | 🟡 Produced for CS2 Review | Maps CS2 conditions into Stage 8 planning waves. |
+| Implementation Plan | `modules/amc/07-implementation-plan/implementation-plan.md` | ✅ CS2 Approved with Conditions | Produced in issue #1199 / PR #1200. Approved by issue #1201 disposition record. |
+| Wave Breakdown | `modules/amc/07-implementation-plan/wave-breakdown.md` | ✅ CS2 Approved with Conditions | Produced in issue #1199 / PR #1200. Approved by issue #1201 disposition record. |
+| Condition Import Matrix | `modules/amc/07-implementation-plan/condition-import-matrix.md` | ✅ CS2 Approved with Conditions | Maps CS2 conditions into Stage 8 planning waves. Approved by issue #1201 disposition record. |
+| CS2 Decision Record - Stage 8 | `modules/amc/07-implementation-plan/cs2-decision-record-stage-8.md` | 🟡 Prepared for PR Review | Records Stage 8 acceptance with conditions. Does not create Stage 9 work. |
 
 ---
 
@@ -134,7 +135,7 @@ This index catalogs all pre-build artifacts for the AMC module, mapped to their 
 
 | Artifact | Location | Status | Notes |
 |----------|----------|--------|-------|
-| Builder Checklist | `modules/amc/08-builder-checklist/builder-checklist.md` | ⬜ Placeholder | Not started. |
+| Builder Checklist | `modules/amc/08-builder-checklist/builder-checklist.md` | ⬜ Placeholder | Not started. Eligible next only after Stage 8 disposition PR merges. |
 | Builder Readiness Attestations | `modules/amc/08-builder-checklist/builder-readiness-attestations.md` | ⬜ Placeholder | Not started. |
 
 ---

--- a/modules/amc/AMC_PRE_BUILD_ARTIFACT_INDEX.md
+++ b/modules/amc/AMC_PRE_BUILD_ARTIFACT_INDEX.md
@@ -127,7 +127,7 @@ This index catalogs all pre-build artifacts for the AMC module, mapped to their 
 | Implementation Plan | `modules/amc/07-implementation-plan/implementation-plan.md` | ✅ CS2 Approved with Conditions | Produced in issue #1199 / PR #1200. Approved by issue #1201 disposition record. |
 | Wave Breakdown | `modules/amc/07-implementation-plan/wave-breakdown.md` | ✅ CS2 Approved with Conditions | Produced in issue #1199 / PR #1200. Approved by issue #1201 disposition record. |
 | Condition Import Matrix | `modules/amc/07-implementation-plan/condition-import-matrix.md` | ✅ CS2 Approved with Conditions | Maps CS2 conditions into Stage 8 planning waves. Approved by issue #1201 disposition record. |
-| CS2 Decision Record - Stage 8 | `modules/amc/07-implementation-plan/cs2-decision-record-stage-8.md` | 🟡 Prepared for PR Review | Records Stage 8 acceptance with conditions. Does not create Stage 9 work. |
+| CS2 Decision Record - Stage 8 | `modules/amc/07-implementation-plan/cs2-decision-record-stage-8.md` | ✅ Current Authority | Records Stage 8 acceptance with conditions. Does not create Stage 9 work. |
 
 ---
 

--- a/modules/amc/BUILD_PROGRESS_TRACKER.md
+++ b/modules/amc/BUILD_PROGRESS_TRACKER.md
@@ -2,15 +2,15 @@
 
 **Module**: App Management Centre (AMC)  
 **Module Slug**: AMC  
-**Last Updated**: 2026-07-02  
-**Updated By**: foreman-v2-agent (wave: amc-stage8-implementation-plan-20260702 - issue #1199; PR #1200; Stage 8 implementation plan artifacts produced for CS2 review. Stages 9-12 remain blocked.)
+**Last Updated**: 2026-07-07  
+**Updated By**: foreman-v2-agent (wave: amc-stage8-cs2-disposition - issue #1201; Stage 8 CS2 disposition record prepared. Stage 9 is eligible next only after this disposition PR is merged as a separate governed wave.)
 
 > **Classification**: ACTIVE  
 > **Document Role**: PRIMARY LIVE CONTROL DOCUMENT - CS2 should use this document as the main live progress dashboard.  
 > **Canon Reference**: `PRE_BUILD_STAGE_MODEL_CANON.md` v1.0.0 plus current ISMS/MMM functional-delivery retrofit lessons  
-> **Current Issue**: [app_management_centre#1199](https://github.com/APGI-cmy/app_management_centre/issues/1199)  
-> **Current PR**: [app_management_centre#1200](https://github.com/APGI-cmy/app_management_centre/pull/1200)  
-> **Update Rule**: This document MUST be updated immediately after every AMC stage issue, wave completion, approval, or readiness/blocker change. Stale tracker text is a governance defect.
+> **Current Issue**: [app_management_centre#1201](https://github.com/APGI-cmy/app_management_centre/issues/1201)  
+> **Current PR**: pending Stage 8 CS2 disposition PR creation  
+> **Update Rule**: This document MUST be updated after every AMC stage issue, wave completion, approval, or readiness/blocker change.
 
 ## Retrofit and Disposition Notes
 
@@ -20,7 +20,8 @@
 - PR #1192 merged Stage 6 QA-to-Red retrofit reference inputs.
 - PR #1194 merged Stage 7 PBFAG retrofit artifacts and `cs2-disposition-pack-stages-5-5a-6-7.md`.
 - PR #1198 recorded explicit CS2 approval with conditions for Stages 5, 5a, 6, and 7.
-- Issue #1199 / PR #1200 opens Stage 8 implementation planning only.
+- PR #1200 produced the Stage 8 Implementation Plan artifacts.
+- Issue #1201 records CS2 disposition of Stage 8 only.
 
 ---
 
@@ -32,63 +33,55 @@
 | 2 | UX Workflow & Wiring Spec | ✅ COMPLETE + 🟡 RETROFIT ADDENDUM PRODUCED | CS2-approved 2026-04-22. CTA/API/Data/Audit matrix merged in #1186. |
 | 3 | FRS | ✅ COMPLETE - CS2 APPROVED + 🟡 RETROFIT ADDENDUM PRODUCED | FR-1900 merged in #1186. |
 | 4 | TRS | ✅ TREATED AS APPROVED + 🟡 RETROFIT ADDENDUM PRODUCED | TR-1900, including TR-1910, merged in #1186. |
-| 5 | Architecture | ✅ CS2 APPROVED WITH CONDITIONS | Stage 5 retrofit obligations remain binding inputs for Stage 8. |
-| 5a | Deployment Execution Strategy | ✅ CS2 APPROVED WITH CONDITIONS | Deployment validation, CI, preview, secret, migration, rollback, health/smoke, and dependency conditions remain binding inputs for Stage 8. |
-| 6 | QA-to-Red | ✅ CS2 APPROVED WITH CONDITIONS | QA-FD and QA-DEPLOY rows remain binding inputs for Stage 8 and later QA-to-Green evidence. |
-| **7** | **PBFAG** | **✅ CS2 APPROVED WITH CONDITIONS** | PBFAG-FD, PBFAG-DEPLOY, PBFAG-QA, tracker/index, and Stage 8 block rows remain binding inputs for Stage 8. |
-| **8** | **Implementation Plan** | **🟡 IN PROGRESS — Produced for CS2 Review** | Issue #1199 / PR #1200 produces implementation-plan artifacts only. No builder checklist, IAA pre-brief, builder appointment, code, build evidence, or build work. |
-| 9 | Builder Checklist | ⬜ Not Started — 🔴 BLOCKED | Blocked until Stage 8 is CS2-accepted and Stage 9 is separately authorized. |
-| 10 | IAA Pre-Brief | ⬜ Not Started — 🔴 BLOCKED | Blocked until canonical sequence authorizes it. |
+| 5 | Architecture | ✅ CS2 APPROVED WITH CONDITIONS | Stage 5 retrofit obligations remain binding inputs for later stages. |
+| 5a | Deployment Execution Strategy | ✅ CS2 APPROVED WITH CONDITIONS | Deployment validation, CI, preview, secret, migration, rollback, health/smoke, and dependency conditions remain binding inputs. |
+| 6 | QA-to-Red | ✅ CS2 APPROVED WITH CONDITIONS | QA-FD and QA-DEPLOY rows remain binding inputs for QA-to-Green evidence. |
+| **7** | **PBFAG** | **✅ CS2 APPROVED WITH CONDITIONS** | PBFAG retrofit rows remain binding inputs. |
+| **8** | **Implementation Plan** | **✅ CS2 APPROVED WITH CONDITIONS — Disposition Prepared** | Issue #1201 records CS2 acceptance. Stage 9 is eligible next only after the disposition PR is merged. |
+| 9 | Builder Checklist | ⬜ Not Started — 🟡 ELIGIBLE NEXT AFTER STAGE 8 DISPOSITION MERGE | Must be opened separately. This PR does not create Stage 9 artifacts. |
+| 10 | IAA Pre-Brief | ⬜ Not Started — 🔴 BLOCKED | Blocked until Stage 9 is authorized and complete. |
 | 11 | Builder Appointment | ⬜ Not Started — 🔴 BLOCKED | No builders appointed. |
 | 12 | Build | ⬜ Not Started — 🔴 BLOCKED | No build authorization. |
 
 ---
 
-## Stage 8 Artifacts
+## Stage 8 Disposition Record
 
-**Status**: Produced for CS2 review  
-**Location**: `modules/amc/07-implementation-plan/`
+**Status**: Prepared for PR review  
+**Location**: `modules/amc/07-implementation-plan/cs2-decision-record-stage-8.md`
 
-Artifacts:
-- `implementation-plan.md`
-- `wave-breakdown.md`
-- `condition-import-matrix.md`
-
----
-
-## Stage 8 Conditions Imported
-
-The Stage 8 package imports:
-
-1. `cs2-decision-record-stages-5-5a-6-7.md`.
-2. Stage 5 route/action/state/audit/degraded-mode map.
-3. Stage 5a deployment validation matrix, including CI and preview boundaries.
-4. Stage 6 QA-FD and QA-DEPLOY rows.
-5. Stage 7 PBFAG-FD, PBFAG-DEPLOY, PBFAG-QA, PBFAG-TRACK, and PBFAG-STAGE8 rows.
-6. First E2E `/alerts` acknowledgement path.
-7. Placeholder/stub rejection rule.
-8. Production approval gates and secret separation.
-9. Supabase migration command freeze.
-10. Rollback planning.
-11. Runtime health and smoke validation.
-12. Dependency readiness and visible degraded-mode behavior.
-13. Complete delivery evidence package.
+**Decision summary**:
+- Stage 8 Implementation Plan: approved with conditions.
+- Stage 9 Builder Checklist: eligible next only after this disposition PR merges and only through a separate governed issue/PR.
 
 ---
 
-## Blocked Downstream Stages
+## Stage 9 Carry-Forward Conditions
 
-- Stage 9 Builder Checklist: not started and blocked.
-- Stage 10 IAA Pre-Brief: not started and blocked.
-- Stage 11 Builder Appointment: not started and blocked.
-- Stage 12 Build: not started and blocked.
+Any later Stage 9 wave must import:
+
+1. Stage 8 implementation plan.
+2. Stage 8 wave breakdown.
+3. Stage 8 condition-import matrix.
+4. Stage 5 route/action/state/audit/degraded-mode obligations.
+5. Stage 5a deployment inheritance.
+6. Secret and environment separation.
+7. Production approval gates and protected/manual surfaces.
+8. Migration command and migration evidence planning.
+9. Rollback or recovery proof requirements.
+10. Runtime health and smoke validation.
+11. Dependency readiness and visible degraded-mode behavior.
+12. Per-wave red-test coverage for W1 through W8.
+13. First E2E `/alerts` acknowledgement path.
+14. Complete evidence package requirements.
+15. Placeholder, stub, skipped, todo, and trivial-proof rejection.
 
 ---
 
 ## Next Action
 
-1. Review Stage 8 PR for issue #1199.
-2. Do not open Stage 9 until Stage 8 is CS2-accepted.
+1. Review and merge the Stage 8 CS2 disposition PR for issue #1201.
+2. After merge, Stage 9 may be opened as a separate governed Builder Checklist wave.
 3. Do not create IAA pre-brief, builder appointment, or build work from this PR.
 
 ---
@@ -96,7 +89,7 @@ The Stage 8 package imports:
 ## References
 
 - [PRE_BUILD_STAGE_MODEL_CANON.md](../../governance/canon/PRE_BUILD_STAGE_MODEL_CANON.md)
-- [cs2-decision-record-stages-5-5a-6-7.md](./06-pbfag/cs2-decision-record-stages-5-5a-6-7.md)
+- [cs2-decision-record-stage-8.md](./07-implementation-plan/cs2-decision-record-stage-8.md)
 - [condition-import-matrix.md](./07-implementation-plan/condition-import-matrix.md)
 - [implementation-plan.md](./07-implementation-plan/implementation-plan.md)
 - [wave-breakdown.md](./07-implementation-plan/wave-breakdown.md)

--- a/modules/amc/BUILD_PROGRESS_TRACKER.md
+++ b/modules/amc/BUILD_PROGRESS_TRACKER.md
@@ -47,7 +47,7 @@
 
 ## Stage 8 Disposition Record
 
-**Status**: Prepared for PR review  
+**Status**: Approved with conditions - disposition PR prepared for review and merge  
 **Location**: `modules/amc/07-implementation-plan/cs2-decision-record-stage-8.md`
 
 **Decision summary**:

--- a/modules/amc/BUILD_PROGRESS_TRACKER.md
+++ b/modules/amc/BUILD_PROGRESS_TRACKER.md
@@ -3,13 +3,13 @@
 **Module**: App Management Centre (AMC)  
 **Module Slug**: AMC  
 **Last Updated**: 2026-07-07  
-**Updated By**: foreman-v2-agent (wave: amc-stage8-cs2-disposition - issue #1201; Stage 8 CS2 disposition record prepared. Stage 9 is eligible next only after this disposition PR is merged as a separate governed wave.)
+**Updated By**: foreman-v2-agent (wave: amc-stage8-cs2-disposition - issue #1201; PR #1202; Stage 8 CS2 disposition record prepared. Stage 9 is eligible next only after this disposition PR is merged as a separate governed wave.)
 
 > **Classification**: ACTIVE  
 > **Document Role**: PRIMARY LIVE CONTROL DOCUMENT - CS2 should use this document as the main live progress dashboard.  
 > **Canon Reference**: `PRE_BUILD_STAGE_MODEL_CANON.md` v1.0.0 plus current ISMS/MMM functional-delivery retrofit lessons  
 > **Current Issue**: [app_management_centre#1201](https://github.com/APGI-cmy/app_management_centre/issues/1201)  
-> **Current PR**: pending Stage 8 CS2 disposition PR creation  
+> **Current PR**: [app_management_centre#1202](https://github.com/APGI-cmy/app_management_centre/pull/1202)  
 > **Update Rule**: This document MUST be updated after every AMC stage issue, wave completion, approval, or readiness/blocker change.
 
 ## Retrofit and Disposition Notes
@@ -21,7 +21,7 @@
 - PR #1194 merged Stage 7 PBFAG retrofit artifacts and `cs2-disposition-pack-stages-5-5a-6-7.md`.
 - PR #1198 recorded explicit CS2 approval with conditions for Stages 5, 5a, 6, and 7.
 - PR #1200 produced the Stage 8 Implementation Plan artifacts.
-- Issue #1201 records CS2 disposition of Stage 8 only.
+- Issue #1201 / PR #1202 records CS2 disposition of Stage 8 only.
 
 ---
 
@@ -37,7 +37,7 @@
 | 5a | Deployment Execution Strategy | ✅ CS2 APPROVED WITH CONDITIONS | Deployment validation, CI, preview, secret, migration, rollback, health/smoke, and dependency conditions remain binding inputs. |
 | 6 | QA-to-Red | ✅ CS2 APPROVED WITH CONDITIONS | QA-FD and QA-DEPLOY rows remain binding inputs for QA-to-Green evidence. |
 | **7** | **PBFAG** | **✅ CS2 APPROVED WITH CONDITIONS** | PBFAG retrofit rows remain binding inputs. |
-| **8** | **Implementation Plan** | **✅ CS2 APPROVED WITH CONDITIONS — Disposition Prepared** | Issue #1201 records CS2 acceptance. Stage 9 is eligible next only after the disposition PR is merged. |
+| **8** | **Implementation Plan** | **✅ CS2 APPROVED WITH CONDITIONS — Disposition Prepared** | Issue #1201 / PR #1202 records CS2 acceptance. Stage 9 is eligible next only after the disposition PR is merged. |
 | 9 | Builder Checklist | ⬜ Not Started — 🟡 ELIGIBLE NEXT AFTER STAGE 8 DISPOSITION MERGE | Must be opened separately. This PR does not create Stage 9 artifacts. |
 | 10 | IAA Pre-Brief | ⬜ Not Started — 🔴 BLOCKED | Blocked until Stage 9 is authorized and complete. |
 | 11 | Builder Appointment | ⬜ Not Started — 🔴 BLOCKED | No builders appointed. |


### PR DESCRIPTION
## Summary

governing_issue: #1201

This PR records CS2 disposition of the AMC Stage 8 Implementation Plan after PR #1200 merged.

## Added / updated artifacts

1. `modules/amc/07-implementation-plan/cs2-decision-record-stage-8.md`
   - Records CS2 approval with conditions for Stage 8.
   - Confirms Stage 9 is eligible next only after this disposition PR merges and only as a separate governed wave.

2. `modules/amc/BUILD_PROGRESS_TRACKER.md`
   - Updates the live tracker to issue #1201.
   - Marks Stage 8 as CS2 approved with conditions / disposition prepared.
   - Keeps Stage 9 not started and downstream stages blocked.

3. `modules/amc/AMC_PRE_BUILD_ARTIFACT_INDEX.md`
   - Adds the Stage 8 CS2 decision record.
   - Marks Stage 8 artifacts as approved with conditions.
   - Keeps Stage 9-12 artifacts unstarted.

4. `.agent-admin/wave-records/amc-wave-record-1201-current.md`
   - Adds the safe wave record for this disposition wave.

## Governance boundary

This PR does not create Stage 9 builder checklist, IAA pre-brief, builder appointment, source code, build evidence, build-readiness certification, or build work.

## Stage posture

After this PR merges, Stage 9 may be opened next as a separate governed Builder Checklist wave.

Closes #1201.