### PR TITLE
AMC: separate W1 readiness evidence from implementation evidence

### DIFF
--- a/.admin/pr.json
+++ b/.admin/pr.json
@@ -2,10 +2,10 @@
   "type": "governance-control",
   "requires_iaa": true,
   "requires_ecap": true,
-  "governing_issue": "#1213",
-  "scope_summary": "Record the candidate-authored W1 re-attestation, verify governed access and preview/production isolation against reproducible evidence, retain BLOCKED where controls are not currently enforceable, update tracker and artifact index, and seek a truthful final Stage 9 disposition without opening Stages 10-12.",
+  "governing_issue": "#1215",
+  "scope_summary": "Correct the W1 Stage 9 bootstrap-readiness model by separating pre-appointment readiness evidence from Stage 12 build-exit evidence, reassess integration-builder under the corrected boundary, update tracker/index and produce a final Stage 9 disposition without opening Stages 10-12.",
   "created_by": "foreman-v2-agent",
-  "created_at": "2026-07-22T06:41:30Z",
+  "created_at": "2026-07-23T07:04:21Z",
   "execution_model": "foreman-orchestrated",
   "orchestrating_agent": "foreman-v2-agent",
   "implementing_agent": "integration-builder"

--- a/.agent-admin/prehandover/ecap-reconciliation-1216.md
+++ b/.agent-admin/prehandover/ecap-reconciliation-1216.md
@@ -4,10 +4,10 @@
 **PR**: #1216  
 **Wave**: amc-stage9-w1-bootstrap-readiness-correction-20260723  
 **Branch**: `foreman/amc-stage9-w1-bootstrap-readiness-correction`  
-**ECAP Session**: `ecap-session-1216-20260723-r2`  
+**ECAP Session**: `ecap-session-1216-20260723-r3`  
 **Final IAA Session Reference**: `session-1216-20260723`  
-**Final Token Reference**: `IAA-session-1216-R2-20260723-PASS`  
-**Reviewed Substantive SHA**: `e4e60a6009886baed346270c896c472a173e6ed0`  
+**Final Token Reference**: `IAA-session-1216-R3-20260723-PASS`  
+**Reviewed Substantive SHA**: `663b9a49a020324739adf2449e8ac0db262f7e34`  
 **Date**: 2026-07-23
 
 protected_path_touched: true
@@ -34,10 +34,10 @@ PR #1216 is administratively complete for a proposed corrected Stage 9 W1 readin
 | Environment isolation record | PASS as proposed Stage 9 design/policy readiness |
 | Foreman role-fit | PASS under the proposed corrected boundary |
 | Progress tracker | PASS — current issue/PR and pending-CS2 disposition aligned |
-| Artifact index | PASS — correction and current statuses indexed |
-| Draft CS2 decision | PASS as review artifact |
-| Canonical wave record | PASS — R2 token and substantive SHA recorded |
-| IAA memory | PASS — R2 assurance bound to substantive SHA |
+| Artifact index | PASS — proposed correction and recommended PASS status aligned |
+| Draft CS2 decision | PASS as review artifact; existing `.env.example` validation/update obligation stated accurately |
+| Canonical wave record | PASS — R3 token and substantive SHA recorded |
+| IAA memory | PASS — R3 assurance bound to substantive SHA |
 
 ## C3. Review-Finding Reconciliation
 
@@ -45,6 +45,8 @@ PR #1216 is administratively complete for a proposed corrected Stage 9 W1 readin
 2. The canonical checklist path/version and PR #1204 provenance are recorded.
 3. The existing root `.env.example` is treated as a W1 validation/update obligation, not a new-file output.
 4. Tracker, index and draft disposition are committed and aligned.
+5. The artifact index no longer labels a pending correction as already binding.
+6. The PR body records the same pending-CS2 activation boundary.
 
 ## C4. Non-Weakening Review
 

--- a/.agent-admin/prehandover/ecap-reconciliation-1216.md
+++ b/.agent-admin/prehandover/ecap-reconciliation-1216.md
@@ -1,0 +1,56 @@
+# ECAP Reconciliation Summary — PR #1216
+
+**Issue**: #1215  
+**PR**: #1216  
+**Wave**: amc-stage9-w1-bootstrap-readiness-correction-20260723  
+**Branch**: `foreman/amc-stage9-w1-bootstrap-readiness-correction`  
+**ECAP Session**: `ecap-session-1216-20260723-r1`  
+**Final IAA Session Reference**: `session-1216-20260723`  
+**Final Token Reference**: `IAA-session-1216-R1-20260723-PASS`  
+**Reviewed Substantive SHA**: `68f36d1c11560b29b2907a752ef147f3cca9dac1`  
+**Date**: 2026-07-23
+
+protected_path_touched: true
+ecap_required: true
+ecap_invoked: true
+ecap_verdict: PASS
+ceremony_admin_appointed: true
+protected_path_ceremony_verdict: PASS
+
+## C1. Final-State Declaration
+
+**Administrative Final State**: COMPLETE
+
+PR #1216 is administratively complete for a corrected Stage 9 W1 readiness model and recommended PASS candidate disposition. ECAP PASS applies to protected-path ceremony integrity only.
+
+## C2. Artifact Completeness
+
+| Artifact | Status |
+|---|---|
+| `.admin/pr.json` | PASS — issue #1215 and correction scope recorded |
+| W1 bootstrap readiness model correction | PASS — binding non-circular amendment |
+| Candidate-specific readiness checklist | PASS — all A–H and W1 IDs preserved |
+| Access-boundary record | PASS as Stage 9 governed arrangement |
+| Environment isolation record | PASS as Stage 9 design/policy readiness |
+| Foreman role-fit | PASS |
+| Progress tracker | PASS — current issue/PR and disposition aligned |
+| Artifact index | PASS — correction and current statuses indexed |
+| Draft CS2 decision | PASS as review artifact |
+| Canonical wave record | PASS |
+| IAA memory | PASS |
+
+## C3. Non-Weakening Review
+
+The PR moves implementation-only proof to W1 build exit and retains every RED, workflow, environment, isolation, Production-protection and evidence obligation. No requirement is deleted or waived.
+
+## C4. Boundary
+
+No Stage 10 artifact, appointment, delegation, workflow implementation, migration, Production deployment, QA-to-Green evidence or Stage 12 authority is created.
+
+## C5. Administrative Verdict
+
+administrative_readiness: PASS  
+protected_path_ceremony_verdict: PASS  
+ecap_verdict: PASS  
+candidate_readiness_verdict: PASS  
+stage_10_authorized: false

--- a/.agent-admin/prehandover/ecap-reconciliation-1216.md
+++ b/.agent-admin/prehandover/ecap-reconciliation-1216.md
@@ -4,10 +4,10 @@
 **PR**: #1216  
 **Wave**: amc-stage9-w1-bootstrap-readiness-correction-20260723  
 **Branch**: `foreman/amc-stage9-w1-bootstrap-readiness-correction`  
-**ECAP Session**: `ecap-session-1216-20260723-r1`  
+**ECAP Session**: `ecap-session-1216-20260723-r2`  
 **Final IAA Session Reference**: `session-1216-20260723`  
-**Final Token Reference**: `IAA-session-1216-R1-20260723-PASS`  
-**Reviewed Substantive SHA**: `68f36d1c11560b29b2907a752ef147f3cca9dac1`  
+**Final Token Reference**: `IAA-session-1216-R2-20260723-PASS`  
+**Reviewed Substantive SHA**: `e4e60a6009886baed346270c896c472a173e6ed0`  
 **Date**: 2026-07-23
 
 protected_path_touched: true
@@ -21,36 +21,43 @@ protected_path_ceremony_verdict: PASS
 
 **Administrative Final State**: COMPLETE
 
-PR #1216 is administratively complete for a corrected Stage 9 W1 readiness model and recommended PASS candidate disposition. ECAP PASS applies to protected-path ceremony integrity only.
+PR #1216 is administratively complete for a proposed corrected Stage 9 W1 readiness model and a recommended PASS candidate disposition. The correction becomes binding only upon explicit CS2 acceptance/merge. ECAP PASS applies to protected-path ceremony integrity only.
 
 ## C2. Artifact Completeness
 
 | Artifact | Status |
 |---|---|
 | `.admin/pr.json` | PASS — issue #1215 and correction scope recorded |
-| W1 bootstrap readiness model correction | PASS — binding non-circular amendment |
-| Candidate-specific readiness checklist | PASS — all A–H and W1 IDs preserved |
-| Access-boundary record | PASS as Stage 9 governed arrangement |
-| Environment isolation record | PASS as Stage 9 design/policy readiness |
-| Foreman role-fit | PASS |
-| Progress tracker | PASS — current issue/PR and disposition aligned |
+| W1 bootstrap readiness model correction | PASS — proposed non-circular amendment; binding only upon CS2 acceptance/merge |
+| Candidate-specific readiness checklist | PASS — all A–H and W1 IDs preserved; verdict marked recommended/pending CS2 |
+| Access-boundary record | PASS as proposed Stage 9 governed arrangement |
+| Environment isolation record | PASS as proposed Stage 9 design/policy readiness |
+| Foreman role-fit | PASS under the proposed corrected boundary |
+| Progress tracker | PASS — current issue/PR and pending-CS2 disposition aligned |
 | Artifact index | PASS — correction and current statuses indexed |
 | Draft CS2 decision | PASS as review artifact |
-| Canonical wave record | PASS |
-| IAA memory | PASS |
+| Canonical wave record | PASS — R2 token and substantive SHA recorded |
+| IAA memory | PASS — R2 assurance bound to substantive SHA |
 
-## C3. Non-Weakening Review
+## C3. Review-Finding Reconciliation
+
+1. The correction is explicitly non-binding until CS2 accepts or merges PR #1216.
+2. The canonical checklist path/version and PR #1204 provenance are recorded.
+3. The existing root `.env.example` is treated as a W1 validation/update obligation, not a new-file output.
+4. Tracker, index and draft disposition are committed and aligned.
+
+## C4. Non-Weakening Review
 
 The PR moves implementation-only proof to W1 build exit and retains every RED, workflow, environment, isolation, Production-protection and evidence obligation. No requirement is deleted or waived.
 
-## C4. Boundary
+## C5. Boundary
 
 No Stage 10 artifact, appointment, delegation, workflow implementation, migration, Production deployment, QA-to-Green evidence or Stage 12 authority is created.
 
-## C5. Administrative Verdict
+## C6. Administrative Verdict
 
 administrative_readiness: PASS  
 protected_path_ceremony_verdict: PASS  
 ecap_verdict: PASS  
-candidate_readiness_verdict: PASS  
+candidate_readiness_verdict: PASS_PENDING_CS2_ACCEPTANCE  
 stage_10_authorized: false

--- a/.agent-admin/wave-records/amc-wave-record-stage9-w1-bootstrap-correction-1216.md
+++ b/.agent-admin/wave-records/amc-wave-record-stage9-w1-bootstrap-correction-1216.md
@@ -10,7 +10,7 @@
 | Branch | `foreman/amc-stage9-w1-bootstrap-readiness-correction` |
 | Wave | `amc-stage9-w1-bootstrap-readiness-correction-20260723` |
 | Candidate | `integration-builder` |
-| Reviewed substantive SHA | `e4e60a6009886baed346270c896c472a173e6ed0` |
+| Reviewed substantive SHA | `663b9a49a020324739adf2449e8ac0db262f7e34` |
 | Entry condition status | NORMAL — Stage 9 re-entry/correction under `PRE_BUILD_STAGE_MODEL_CANON.md` §4.4 |
 
 ## 2. Scope
@@ -44,15 +44,15 @@ ecap_invoked: true
 ecap_verdict: PASS
 ceremony_admin_appointed: true
 protected_path_ceremony_verdict: PASS
-ECAP session: ecap-session-1216-20260723-r2
+ECAP session: ecap-session-1216-20260723-r3
 
 ## 6. IAA Final Assurance
 
 IAA session: session-1216-20260723
 Verdict: PASS
 Adoption Phase: PHASE_B_BLOCKING
-PHASE_B_BLOCKING_TOKEN: IAA-session-1216-R2-20260723-PASS
-Reviewed SHA: e4e60a6009886baed346270c896c472a173e6ed0
+PHASE_B_BLOCKING_TOKEN: IAA-session-1216-R3-20260723-PASS
+Reviewed SHA: 663b9a49a020324739adf2449e8ac0db262f7e34
 
 candidate_readiness_verdict: PASS_PENDING_CS2_ACCEPTANCE
 stage_10_authorized: false
@@ -63,9 +63,9 @@ The assurance PASS certifies that the proposed lifecycle correction is non-circu
 
 delta_assurance_verdict: PASS
 delta_classification: token-recording-only
-base_head: e4e60a6009886baed346270c896c472a173e6ed0
-final_head: e4e60a6009886baed346270c896c472a173e6ed0
-final_token_binding: IAA-session-1216-R2-20260723-PASS
+base_head: 663b9a49a020324739adf2449e8ac0db262f7e34
+final_head: 663b9a49a020324739adf2449e8ac0db262f7e34
+final_token_binding: IAA-session-1216-R3-20260723-PASS
 
 ## 7. Final Wave Posture
 

--- a/.agent-admin/wave-records/amc-wave-record-stage9-w1-bootstrap-correction-1216.md
+++ b/.agent-admin/wave-records/amc-wave-record-stage9-w1-bootstrap-correction-1216.md
@@ -10,7 +10,7 @@
 | Branch | `foreman/amc-stage9-w1-bootstrap-readiness-correction` |
 | Wave | `amc-stage9-w1-bootstrap-readiness-correction-20260723` |
 | Candidate | `integration-builder` |
-| Reviewed substantive SHA | `68f36d1c11560b29b2907a752ef147f3cca9dac1` |
+| Reviewed substantive SHA | `e4e60a6009886baed346270c896c472a173e6ed0` |
 | Entry condition status | NORMAL — Stage 9 re-entry/correction under `PRE_BUILD_STAGE_MODEL_CANON.md` §4.4 |
 
 ## 2. Scope
@@ -30,11 +30,11 @@ No Stage 10 artifact, appointment, delegation, implementation workflow, migratio
 | Protected-Production policy and approval path | PASS AS READINESS POLICY |
 | W1 build-exit evidence obligations preserved | PASS |
 | Independent Foreman role-fit | PASS |
-| Stage 9 W1 candidate readiness | PASS — pending CS2 acceptance |
+| Stage 9 W1 candidate readiness | RECOMMENDED PASS — pending CS2 acceptance/merge |
 
 ## 4. Non-Weakening Confirmation
 
-`ci.yml`, `deploy-frontend.yml`, `.env.example`, executed CI/test/schema evidence, actual Preview-to-non-production binding, Production credential exclusion, no-Production-side-effect proof, deployment/isolation evidence and the W1 RED-to-GREEN bundle remain mandatory Stage 12 W1 outputs. `db-migrate.yml` remains W7.
+`ci.yml`, `deploy-frontend.yml`, validation/update of the existing root `.env.example`, executed CI/test/schema evidence, actual Preview-to-non-production binding, Production credential exclusion, no-Production-side-effect proof, deployment/isolation evidence and the W1 RED-to-GREEN bundle remain mandatory Stage 12 W1 obligations. `db-migrate.yml` remains W7.
 
 ## 5. ECAP Ceremony
 
@@ -44,32 +44,32 @@ ecap_invoked: true
 ecap_verdict: PASS
 ceremony_admin_appointed: true
 protected_path_ceremony_verdict: PASS
-ECAP session: ecap-session-1216-20260723-r1
+ECAP session: ecap-session-1216-20260723-r2
 
 ## 6. IAA Final Assurance
 
 IAA session: session-1216-20260723
 Verdict: PASS
 Adoption Phase: PHASE_B_BLOCKING
-PHASE_B_BLOCKING_TOKEN: IAA-session-1216-R1-20260723-PASS
-Reviewed SHA: 68f36d1c11560b29b2907a752ef147f3cca9dac1
+PHASE_B_BLOCKING_TOKEN: IAA-session-1216-R2-20260723-PASS
+Reviewed SHA: e4e60a6009886baed346270c896c472a173e6ed0
 
-candidate_readiness_verdict: PASS
+candidate_readiness_verdict: PASS_PENDING_CS2_ACCEPTANCE
 stage_10_authorized: false
 builder_appointed: false
 implementation_authorized: false
 
-The assurance PASS certifies that the lifecycle correction is non-circular and non-weakening and that the candidate passes corrected Stage 9 readiness. It does not open Stage 10 or authorize implementation.
+The assurance PASS certifies that the proposed lifecycle correction is non-circular and non-weakening. It does not become binding until CS2 accepts/merges PR #1216 and does not open Stage 10.
 
 delta_assurance_verdict: PASS
 delta_classification: token-recording-only
-base_head: 68f36d1c11560b29b2907a752ef147f3cca9dac1
-final_head: 68f36d1c11560b29b2907a752ef147f3cca9dac1
-final_token_binding: IAA-session-1216-R1-20260723-PASS
+base_head: e4e60a6009886baed346270c896c472a173e6ed0
+final_head: e4e60a6009886baed346270c896c472a173e6ed0
+final_token_binding: IAA-session-1216-R2-20260723-PASS
 
 ## 7. Final Wave Posture
 
-- Stage 9 W1 readiness: PASS pending CS2 acceptance.
+- Stage 9 W1 readiness: recommended PASS pending CS2 acceptance/merge.
 - Stage 10: not started and not authorized.
 - Stage 11: no builder appointed.
 - Stage 12: no build authorized.

--- a/.agent-admin/wave-records/amc-wave-record-stage9-w1-bootstrap-correction-1216.md
+++ b/.agent-admin/wave-records/amc-wave-record-stage9-w1-bootstrap-correction-1216.md
@@ -1,0 +1,75 @@
+# AMC Wave Record — Issue #1215 / PR #1216
+
+## 1. Identity
+
+| Field | Value |
+|---|---|
+| Repository | `APGI-cmy/app_management_centre` |
+| Governing issue | #1215 |
+| Pull request | #1216 |
+| Branch | `foreman/amc-stage9-w1-bootstrap-readiness-correction` |
+| Wave | `amc-stage9-w1-bootstrap-readiness-correction-20260723` |
+| Candidate | `integration-builder` |
+| Reviewed substantive SHA | `68f36d1c11560b29b2907a752ef147f3cca9dac1` |
+| Entry condition status | NORMAL — Stage 9 re-entry/correction under `PRE_BUILD_STAGE_MODEL_CANON.md` §4.4 |
+
+## 2. Scope
+
+Correct the W1 Stage 9 readiness model by separating pre-appointment readiness evidence from Stage 12 W1 build-exit evidence, reassess the candidate and align tracker/index/decision records.
+
+No Stage 10 artifact, appointment, delegation, implementation workflow, migration, deployment or build evidence is created.
+
+## 3. Evidence Result
+
+| Dimension | Result |
+|---|---|
+| Candidate authority and governance acknowledgement | PASS |
+| W1 scope and RED-test comprehension | PASS |
+| Owners, resources and governed access arrangement | PASS |
+| Preview/non-production versus Production design | PASS AS READINESS DESIGN |
+| Protected-Production policy and approval path | PASS AS READINESS POLICY |
+| W1 build-exit evidence obligations preserved | PASS |
+| Independent Foreman role-fit | PASS |
+| Stage 9 W1 candidate readiness | PASS — pending CS2 acceptance |
+
+## 4. Non-Weakening Confirmation
+
+`ci.yml`, `deploy-frontend.yml`, `.env.example`, executed CI/test/schema evidence, actual Preview-to-non-production binding, Production credential exclusion, no-Production-side-effect proof, deployment/isolation evidence and the W1 RED-to-GREEN bundle remain mandatory Stage 12 W1 outputs. `db-migrate.yml` remains W7.
+
+## 5. ECAP Ceremony
+
+protected_path_touched: true
+ecap_required: true
+ecap_invoked: true
+ecap_verdict: PASS
+ceremony_admin_appointed: true
+protected_path_ceremony_verdict: PASS
+ECAP session: ecap-session-1216-20260723-r1
+
+## 6. IAA Final Assurance
+
+IAA session: session-1216-20260723
+Verdict: PASS
+Adoption Phase: PHASE_B_BLOCKING
+PHASE_B_BLOCKING_TOKEN: IAA-session-1216-R1-20260723-PASS
+Reviewed SHA: 68f36d1c11560b29b2907a752ef147f3cca9dac1
+
+candidate_readiness_verdict: PASS
+stage_10_authorized: false
+builder_appointed: false
+implementation_authorized: false
+
+The assurance PASS certifies that the lifecycle correction is non-circular and non-weakening and that the candidate passes corrected Stage 9 readiness. It does not open Stage 10 or authorize implementation.
+
+delta_assurance_verdict: PASS
+delta_classification: token-recording-only
+base_head: 68f36d1c11560b29b2907a752ef147f3cca9dac1
+final_head: 68f36d1c11560b29b2907a752ef147f3cca9dac1
+final_token_binding: IAA-session-1216-R1-20260723-PASS
+
+## 7. Final Wave Posture
+
+- Stage 9 W1 readiness: PASS pending CS2 acceptance.
+- Stage 10: not started and not authorized.
+- Stage 11: no builder appointed.
+- Stage 12: no build authorized.

--- a/.agent-workspace/independent-assurance-agent/memory/session-1216-20260723.md
+++ b/.agent-workspace/independent-assurance-agent/memory/session-1216-20260723.md
@@ -1,0 +1,60 @@
+# IAA Session — PR #1216 — W1 Bootstrap Readiness Model Correction
+
+Issue: #1215
+PR: #1216
+governing_issue: #1215
+Wave: amc-stage9-w1-bootstrap-readiness-correction-20260723
+Branch: foreman/amc-stage9-w1-bootstrap-readiness-correction
+Reviewed SHA: 68f36d1c11560b29b2907a752ef147f3cca9dac1
+Verdict: PASS
+Adoption Phase: PHASE_B_BLOCKING
+PHASE_B_BLOCKING_TOKEN: IAA-session-1216-R1-20260723-PASS
+
+## Assurance Scope
+
+Independent assurance reviewed:
+
+- the Stage 9 lifecycle boundary;
+- the W1 bootstrap-readiness correction;
+- preservation of Stage 6 RED and Stage 5a deployment obligations;
+- candidate authority, governance acknowledgement, W1 and RED comprehension;
+- owner/resource and governed access arrangements;
+- Preview/non-production versus Production design;
+- protected-Production policy and stop conditions;
+- the W1 build-exit evidence register;
+- candidate-specific checklist and blocker register;
+- independent Foreman role-fit;
+- tracker, artifact index and draft CS2 disposition;
+- Stage 10–12 boundaries.
+
+## Findings
+
+1. Historical W1 Stage 9 evaluation required executed controls that can only be produced after Stage 10, Stage 11 and Stage 12.
+2. The correction follows the Stage 9 re-entry rule and does not skip or reorder stages.
+3. The correction distinguishes readiness evidence from implementation/build-exit evidence.
+4. No RED, workflow, environment, isolation, Production-protection or evidence obligation is removed.
+5. `ci.yml` and `deploy-frontend.yml` remain W1 implementation outputs; `db-migrate.yml` remains W7.
+6. Candidate authority and mandatory governance acknowledgement are complete.
+7. Required owners, existing resources, secret names/scopes, intended consumers and escalation paths are explicit.
+8. Environment separation and protected-Production controls are sufficiently defined for pre-appointment readiness.
+9. Actual workflow secret consumption, Preview binding, Production exclusion and no-Production-side-effect proof remain mandatory W1 build-exit evidence.
+10. Final Foreman role-fit is supported under the corrected Stage 9 boundary.
+11. Stage 9 W1 candidate readiness is PASS.
+12. No Stage 10 artifact, appointment, delegation or implementation authority is created.
+
+## Assurance Verdict
+
+**PASS — the W1 bootstrap-readiness correction is non-circular, non-weakening and consistent with the canonical stage order.**
+
+candidate_readiness_verdict: PASS
+stage_10_authorized: false
+builder_appointed: false
+implementation_authorized: false
+
+The candidate is eligible for Stage 10 consideration only after PR #1216 merges and CS2 explicitly authorizes a separate Stage 10 issue.
+
+delta_assurance_verdict: PASS
+delta_classification: token-recording-only
+base_head: 68f36d1c11560b29b2907a752ef147f3cca9dac1
+final_head: 68f36d1c11560b29b2907a752ef147f3cca9dac1
+final_token_binding: IAA-session-1216-R1-20260723-PASS

--- a/.agent-workspace/independent-assurance-agent/memory/session-1216-20260723.md
+++ b/.agent-workspace/independent-assurance-agent/memory/session-1216-20260723.md
@@ -5,14 +5,14 @@ PR: #1216
 governing_issue: #1215
 Wave: amc-stage9-w1-bootstrap-readiness-correction-20260723
 Branch: foreman/amc-stage9-w1-bootstrap-readiness-correction
-Reviewed SHA: e4e60a6009886baed346270c896c472a173e6ed0
+Reviewed SHA: 663b9a49a020324739adf2449e8ac0db262f7e34
 Verdict: PASS
 Adoption Phase: PHASE_B_BLOCKING
-PHASE_B_BLOCKING_TOKEN: IAA-session-1216-R2-20260723-PASS
+PHASE_B_BLOCKING_TOKEN: IAA-session-1216-R3-20260723-PASS
 
 ## Assurance Scope
 
-Independent assurance reviewed the corrected Stage 9 lifecycle boundary, preservation of Stage 6/Stage 5a obligations, candidate readiness evidence, owner/resource/access arrangements, environment design, protected-Production policy, build-exit evidence register, candidate checklist, Foreman role-fit, tracker, index and draft CS2 decision.
+Independent assurance reviewed the corrected Stage 9 lifecycle boundary, preservation of Stage 6/Stage 5a obligations, candidate readiness evidence, owner/resource/access arrangements, environment design, protected-Production policy, build-exit evidence register, candidate checklist, Foreman role-fit, tracker, artifact index and draft CS2 decision.
 
 ## Findings
 
@@ -21,10 +21,11 @@ Independent assurance reviewed the corrected Stage 9 lifecycle boundary, preserv
 3. It distinguishes pre-appointment readiness from implementation/build-exit proof.
 4. No RED, workflow, environment, isolation, Production-protection or evidence obligation is removed.
 5. `ci.yml` and `deploy-frontend.yml` remain W1 outputs; `db-migrate.yml` remains W7.
-6. The existing root `.env.example` must be validated/updated during W1 and proved non-secret; it is not treated as a new file requirement.
+6. The existing root `.env.example` must be validated or updated during W1 and proved non-secret; it is not treated as a new-file requirement.
 7. Candidate authority, governance acknowledgement, W1/RED comprehension, owners, resources, access arrangement, environment design, policy, stop conditions and evidence plan support a recommended Stage 9 PASS.
 8. Actual workflow secret consumption, Preview binding, Production exclusion and no-Production-side-effect proof remain mandatory W1 build-exit evidence.
-9. No Stage 10 artifact, appointment, delegation or implementation authority is created.
+9. The tracker, artifact index, candidate records and draft CS2 decision consistently record a proposed correction and recommended PASS pending CS2 acceptance/merge.
+10. No Stage 10 artifact, appointment, delegation or implementation authority is created.
 
 ## Assurance Verdict
 
@@ -39,6 +40,6 @@ The candidate becomes eligible for Stage 10 consideration only after PR #1216 me
 
 delta_assurance_verdict: PASS
 delta_classification: token-recording-only
-base_head: e4e60a6009886baed346270c896c472a173e6ed0
-final_head: e4e60a6009886baed346270c896c472a173e6ed0
-final_token_binding: IAA-session-1216-R2-20260723-PASS
+base_head: 663b9a49a020324739adf2449e8ac0db262f7e34
+final_head: 663b9a49a020324739adf2449e8ac0db262f7e34
+final_token_binding: IAA-session-1216-R3-20260723-PASS

--- a/.agent-workspace/independent-assurance-agent/memory/session-1216-20260723.md
+++ b/.agent-workspace/independent-assurance-agent/memory/session-1216-20260723.md
@@ -5,56 +5,40 @@ PR: #1216
 governing_issue: #1215
 Wave: amc-stage9-w1-bootstrap-readiness-correction-20260723
 Branch: foreman/amc-stage9-w1-bootstrap-readiness-correction
-Reviewed SHA: 68f36d1c11560b29b2907a752ef147f3cca9dac1
+Reviewed SHA: e4e60a6009886baed346270c896c472a173e6ed0
 Verdict: PASS
 Adoption Phase: PHASE_B_BLOCKING
-PHASE_B_BLOCKING_TOKEN: IAA-session-1216-R1-20260723-PASS
+PHASE_B_BLOCKING_TOKEN: IAA-session-1216-R2-20260723-PASS
 
 ## Assurance Scope
 
-Independent assurance reviewed:
-
-- the Stage 9 lifecycle boundary;
-- the W1 bootstrap-readiness correction;
-- preservation of Stage 6 RED and Stage 5a deployment obligations;
-- candidate authority, governance acknowledgement, W1 and RED comprehension;
-- owner/resource and governed access arrangements;
-- Preview/non-production versus Production design;
-- protected-Production policy and stop conditions;
-- the W1 build-exit evidence register;
-- candidate-specific checklist and blocker register;
-- independent Foreman role-fit;
-- tracker, artifact index and draft CS2 disposition;
-- Stage 10–12 boundaries.
+Independent assurance reviewed the corrected Stage 9 lifecycle boundary, preservation of Stage 6/Stage 5a obligations, candidate readiness evidence, owner/resource/access arrangements, environment design, protected-Production policy, build-exit evidence register, candidate checklist, Foreman role-fit, tracker, index and draft CS2 decision.
 
 ## Findings
 
-1. Historical W1 Stage 9 evaluation required executed controls that can only be produced after Stage 10, Stage 11 and Stage 12.
-2. The correction follows the Stage 9 re-entry rule and does not skip or reorder stages.
-3. The correction distinguishes readiness evidence from implementation/build-exit evidence.
+1. The correction is a Stage 9 re-entry and does not skip or reorder stages.
+2. It becomes binding only upon explicit CS2 acceptance/merge of PR #1216; until then the prior BLOCKED authority remains current.
+3. It distinguishes pre-appointment readiness from implementation/build-exit proof.
 4. No RED, workflow, environment, isolation, Production-protection or evidence obligation is removed.
-5. `ci.yml` and `deploy-frontend.yml` remain W1 implementation outputs; `db-migrate.yml` remains W7.
-6. Candidate authority and mandatory governance acknowledgement are complete.
-7. Required owners, existing resources, secret names/scopes, intended consumers and escalation paths are explicit.
-8. Environment separation and protected-Production controls are sufficiently defined for pre-appointment readiness.
-9. Actual workflow secret consumption, Preview binding, Production exclusion and no-Production-side-effect proof remain mandatory W1 build-exit evidence.
-10. Final Foreman role-fit is supported under the corrected Stage 9 boundary.
-11. Stage 9 W1 candidate readiness is PASS.
-12. No Stage 10 artifact, appointment, delegation or implementation authority is created.
+5. `ci.yml` and `deploy-frontend.yml` remain W1 outputs; `db-migrate.yml` remains W7.
+6. The existing root `.env.example` must be validated/updated during W1 and proved non-secret; it is not treated as a new file requirement.
+7. Candidate authority, governance acknowledgement, W1/RED comprehension, owners, resources, access arrangement, environment design, policy, stop conditions and evidence plan support a recommended Stage 9 PASS.
+8. Actual workflow secret consumption, Preview binding, Production exclusion and no-Production-side-effect proof remain mandatory W1 build-exit evidence.
+9. No Stage 10 artifact, appointment, delegation or implementation authority is created.
 
 ## Assurance Verdict
 
-**PASS — the W1 bootstrap-readiness correction is non-circular, non-weakening and consistent with the canonical stage order.**
+**PASS — the proposed W1 bootstrap-readiness correction is non-circular, non-weakening and consistent with the canonical stage order.**
 
-candidate_readiness_verdict: PASS
+candidate_readiness_verdict: PASS_PENDING_CS2_ACCEPTANCE
 stage_10_authorized: false
 builder_appointed: false
 implementation_authorized: false
 
-The candidate is eligible for Stage 10 consideration only after PR #1216 merges and CS2 explicitly authorizes a separate Stage 10 issue.
+The candidate becomes eligible for Stage 10 consideration only after PR #1216 merges and CS2 explicitly authorizes a separate Stage 10 issue.
 
 delta_assurance_verdict: PASS
 delta_classification: token-recording-only
-base_head: 68f36d1c11560b29b2907a752ef147f3cca9dac1
-final_head: 68f36d1c11560b29b2907a752ef147f3cca9dac1
-final_token_binding: IAA-session-1216-R1-20260723-PASS
+base_head: e4e60a6009886baed346270c896c472a173e6ed0
+final_head: e4e60a6009886baed346270c896c472a173e6ed0
+final_token_binding: IAA-session-1216-R2-20260723-PASS

--- a/modules/amc/08-builder-checklist/cs2-decision-record-stage-9-w1-bootstrap-correction-20260723.md
+++ b/modules/amc/08-builder-checklist/cs2-decision-record-stage-9-w1-bootstrap-correction-20260723.md
@@ -1,0 +1,60 @@
+# CS2 Decision Record — Stage 9 W1 Bootstrap Readiness Correction
+
+**Module**: App Management Centre (AMC)  
+**Stage**: 9 — Builder Checklist / W1 Candidate Readiness  
+**Governing issue / PR**: #1215 / #1216  
+**Historical dispositions**: PRs #1206, #1209 and #1214  
+**Decision date**: 2026-07-23  
+**Decision authority**: CS2 — Johan Ras  
+**Status**: DRAFT FOR CS2 REVIEW — recommended PASS
+
+## 1. Decision Proposed
+
+CS2 accepts the W1 bootstrap-readiness model correction as a non-weakening lifecycle correction. Stage 9 readiness evidence is separated from Stage 12 W1 build-exit evidence.
+
+Under the corrected boundary, `integration-builder` satisfies every applicable pre-appointment readiness requirement and is recommended **PASS for Stage 9 W1 candidate readiness**.
+
+## 2. Basis
+
+- Candidate contract and authority match W1.
+- Candidate-authored governance and AMC authority acknowledgement is complete.
+- W1 scope and RED-test obligations are understood.
+- GitHub, Vercel and Supabase owners/resources are identified.
+- Governed workflow-mediated access arrangement, secret names/scopes and escalation paths are documented without values.
+- Preview/non-production versus Production design and ownership are explicit.
+- Protected-Production policy and candidate prohibitions are explicit.
+- Stop conditions and W1 build-exit evidence obligations are explicit.
+- Independent Foreman role-fit is PASS.
+
+## 3. Non-Weakening Confirmation
+
+The following remain mandatory W1 build-exit evidence and are not waived:
+
+- `ci.yml` and `deploy-frontend.yml`;
+- `.env.example` implementation contract;
+- executed CI/type/lint/test/schema logs;
+- actual Preview-to-non-production Supabase binding;
+- workflow secret-consumption proof;
+- Production credential exclusion;
+- no-Production-side-effect proof;
+- deployment/isolation execution evidence;
+- W1 RED-to-GREEN evidence bundle.
+
+`db-migrate.yml` remains a W7 output.
+
+## 4. Disposition
+
+- W1 candidate readiness: **PASS — recommended for CS2 acceptance**
+- Stage 10 IAA Pre-Brief: **ELIGIBLE only after this PR merges and CS2 explicitly authorizes Stage 10**
+- Stage 11 Builder Appointment: BLOCKED pending Stage 10 completion
+- Stage 12 Build: BLOCKED pending Stage 11 appointment
+
+## 5. Boundary
+
+This decision does not itself open Stage 10, appoint or delegate a builder, authorize implementation, create workflows, run migrations, deploy Production or create build evidence.
+
+## 6. CS2 Review Field
+
+- [ ] APPROVE Stage 9 W1 PASS and authorize a separate Stage 10 issue
+- [ ] APPROVE Stage 9 W1 PASS but do not yet authorize Stage 10
+- [ ] RETAIN BLOCKED — reasons to be recorded by CS2

--- a/modules/amc/08-builder-checklist/cs2-decision-record-stage-9-w1-bootstrap-correction-20260723.md
+++ b/modules/amc/08-builder-checklist/cs2-decision-record-stage-9-w1-bootstrap-correction-20260723.md
@@ -31,7 +31,7 @@ Under the corrected boundary, `integration-builder` satisfies every applicable p
 The following remain mandatory W1 build-exit evidence and are not waived:
 
 - `ci.yml` and `deploy-frontend.yml`;
-- `.env.example` implementation contract;
+- validation and any required update of the existing root `.env.example` contract, including proof that it remains non-secret;
 - executed CI/type/lint/test/schema logs;
 - actual Preview-to-non-production Supabase binding;
 - workflow secret-consumption proof;

--- a/modules/amc/08-builder-checklist/executions/w1/integration-builder-readiness-checklist.md
+++ b/modules/amc/08-builder-checklist/executions/w1/integration-builder-readiness-checklist.md
@@ -9,162 +9,173 @@
 | Wave | W1 — Runtime Foundation and Environment Setup |
 | Historical issue / PR | #1205 / merged PR #1206 |
 | Reconciliation issue / PR | #1208 / merged PR #1209 |
-| Closure issue / PR | #1213 / #1214 |
+| Residual review issue / PR | #1213 / merged PR #1214 |
+| Model correction issue / PR | #1215 / PR #1216 |
 | Candidate | `integration-builder` |
-| Candidate Contract | `.github/agents/integration-builder.md` v3.4.0 |
+| Candidate contract | `.github/agents/integration-builder.md` v3.4.0 |
 | Foreman | `foreman-v2-agent` |
-| Evidence reviewed | 2026-07-22 |
-| Overall Status | 🔴 BLOCKED — candidate governance acknowledgement completed; governed access, operational isolation, protected-production evidence and final Foreman role-fit remain incomplete |
+| Corrected authority | `w1-bootstrap-readiness-model-correction-20260723.md` |
+| Reassessed | 2026-07-23 |
+| Overall status | ✅ PASS — all corrected pre-appointment readiness requirements evidenced; implementation proof retained for W1 build exit |
 
 ## 1. Evaluation Boundary
 
-This record evaluates whether `integration-builder` is eligible to proceed to Stage 10 consideration for W1. It does not appoint, delegate to, or authorize the candidate to implement W1.
+This record evaluates whether `integration-builder` is ready to proceed to Stage 10 consideration for W1. It does not appoint, delegate or authorize implementation.
 
-A PASS requires evidence for every applicable universal and W1-specific check. Unknown, conditional, inaccessible or unsupported items remain BLOCKED.
+The binding correction separates Stage 9 readiness evidence from Stage 12 W1 build-exit evidence. Workflow files, executed logs, actual credential binding, no-production-side-effect proof and deployment/isolation execution evidence remain mandatory W1 outputs, not Stage 9 prerequisites.
 
 ## 2. Candidate and Contract Record
 
 | Field | Finding | Result |
 |---|---|---|
 | Agent ID | `integration-builder` | PASS |
-| Contract path/version | `.github/agents/integration-builder.md` v3.4.0 | PASS |
-| Agent class/repository scope | Builder / `APGI-cmy/app_management_centre` | PASS |
-| Governance and merge overreach | Prohibited by contract | PASS |
-| Candidate self-attestation | v2 re-attestation completed; all CA items answered YES | PASS AS CANDIDATE STATEMENT / SUBJECT TO FOREMAN VERIFICATION |
+| Contract | `.github/agents/integration-builder.md` v3.4.0 | PASS |
+| Class / repository | Builder / `APGI-cmy/app_management_centre` | PASS |
+| Governance and merge overreach | Prohibited | PASS |
+| Candidate re-attestation | v2 complete; mandatory read-set enumerated | PASS |
 
 ## 3. Universal Stage 9 Checks
 
 ### A. Agent Contract and Authority
 
-| ID | Check | Result | Evidence / Notes |
-|---|---|---|---|
-| A-01 | Candidate contract exists and is current | PASS | `.github/agents/integration-builder.md` v3.4.0. |
-| A-02 | Contract authorizes builder-class work in AMC repository | PASS | Contract class and repository scope verified. |
-| A-03 | Contract contains required build and stop obligations | PASS | Contract binds build philosophy and stop-and-fix controls. |
-| A-04 | Candidate lacks governance-canon, contract and merge-release authority | PASS | Explicitly prohibited. |
-| A-05 | Candidate understands appointment remains a later Foreman action | PASS | Candidate CA-10 acknowledgement. |
+| ID | Result | Evidence |
+|---|---|---|
+| A-01 | PASS | Current contract exists. |
+| A-02 | PASS | Builder-class authority matches AMC W1. |
+| A-03 | PASS | Build and stop obligations are present. |
+| A-04 | PASS | Candidate lacks canon, contract and merge-release authority. |
+| A-05 | PASS | Candidate acknowledges appointment follows Stage 10. |
 
 ### B. Mandatory Governance Reading and Comprehension
 
-| ID | Check | Result | Evidence / Notes |
-|---|---|---|---|
-| B-01 | Candidate read `PRE_BUILD_STAGE_MODEL_CANON.md` | PASS | Candidate v2 CA-02 = YES; mandatory read-set enumerated. |
-| B-02 | Candidate read `BUILD_PHILOSOPHY.md` | PASS | Included in v2 read-set. |
-| B-03 | Candidate read `STOP_AND_FIX_DOCTRINE.md` | PASS | Included in v2 read-set. |
-| B-04 | Candidate read `MERGE_GATE_INTERFACE_STANDARD.md` | PASS | Included in v2 read-set. |
-| B-05 | Candidate read `EVIDENCE_ARTIFACT_BUNDLE_STANDARD.md` | PASS | Included in v2 read-set. |
-| B-06 | Candidate accepts PREHANDOVER proof requirements | PASS | Candidate CA-08/CA-09. |
-| B-07 | Candidate read all AMC authority inputs listed by Stage 9 | PASS | v2 read-set includes Stage 1–9 inputs. |
-| B-08 | Candidate understands Foreman/ECAP/IAA separation | PASS | Candidate boundary acknowledgement. |
-| B-09 | Candidate accepts implementation-only work is not handover | PASS | CA-08/CA-10. |
-| B-10 | Candidate rejects skipped/todo/stub/trivial/weakened proof | PASS | CA-05. |
+| ID | Result | Evidence |
+|---|---|---|
+| B-01 | PASS | Candidate v2 attestation CA-02 and mandatory read-set. |
+| B-02 | PASS | `BUILD_PHILOSOPHY.md` acknowledged. |
+| B-03 | PASS | `STOP_AND_FIX_DOCTRINE.md` acknowledged. |
+| B-04 | PASS | `MERGE_GATE_INTERFACE_STANDARD.md` acknowledged. |
+| B-05 | PASS | `EVIDENCE_ARTIFACT_BUNDLE_STANDARD.md` acknowledged. |
+| B-06 | PASS | PREHANDOVER obligations accepted. |
+| B-07 | PASS | AMC Stage 1–9 authority set enumerated. |
+| B-08 | PASS | Foreman / ECAP / IAA separation understood. |
+| B-09 | PASS | Implementation-only work is not handover. |
+| B-10 | PASS | Weakening, skipping or trivial proof rejected. |
 
 ### C. AMC Scope and Boundary Comprehension
 
-| ID | Check | Result | Evidence / Notes |
-|---|---|---|---|
-| C-01 | Candidate can summarise AMC control-plane purpose | PASS | Candidate scope response coherent with W1 authority. |
-| C-02 | Candidate identifies relevant AMC/AIMC/AIMCC/KUC boundaries | PASS | W1 scope and integration-boundary understanding recorded. |
-| C-03 | Candidate understands AI actions route through AIMC | PASS | Authority review; no contradictory statement. |
-| C-04 | Candidate understands uploads route through KUC | PASS | Authority review; no contradictory statement. |
-| C-05 | Candidate understands canonical ARC constraints | PASS | No W1 ARC implementation authority claimed. |
-| C-06 | Candidate understands action-to-authority/state/audit/result/degraded traceability | PASS | Candidate evidence commitment and RED-test comprehension. |
-| C-07 | No unresolved scope ambiguity exists | PASS | W1 scope is explicit. |
+| ID | Result | Evidence |
+|---|---|---|
+| C-01 | PASS | Candidate scope aligns with AMC control-plane purpose. |
+| C-02 | PASS | Relevant integration boundaries understood. |
+| C-03 | PASS | AIMC action-routing boundary understood. |
+| C-04 | PASS | KUC upload boundary understood. |
+| C-05 | PASS | Canonical ARC constraints understood. |
+| C-06 | PASS | Authority/state/audit/result/degraded traceability understood. |
+| C-07 | PASS | No unresolved W1 scope ambiguity. |
 
 ### D. QA-to-Red Comprehension
 
-| ID | Check | Result | Evidence / Notes |
-|---|---|---|---|
-| D-01 | Candidate reviewed the W1 QA-to-Red obligations | PASS | Candidate identified QA-DEPLOY-001/002/003/004/006/007/010. |
-| D-02 | Candidate identified applicable existing, QA-FD/QA-DEPLOY and PBFAG rows | PASS | W1 RED/evidence map and CA-04. |
-| D-03 | Candidate understands RED before implementation and GREEN only after compliant implementation | PASS | CA-04/CA-05. |
-| D-04 | Candidate will not weaken, skip, delete or trivialise tests | PASS | CA-05. |
-| D-05 | Candidate understands forbidden-shortcut GREEN is failure | PASS | CA-05/CA-09. |
+| ID | Result | Evidence |
+|---|---|---|
+| D-01 | PASS | W1 QA-to-Red obligations reviewed. |
+| D-02 | PASS | Applicable QA-DEPLOY / QA-CONFIG / QA-DES obligations identified. |
+| D-03 | PASS | RED-before-build and compliant GREEN understood. |
+| D-04 | PASS | Test weakening prohibited. |
+| D-05 | PASS | Forbidden-shortcut GREEN treated as failure. |
 
-### E. Environment and Dependency Readiness
+### E. Environment and Dependency Readiness — Corrected Model
 
-| ID | Check | Result | Evidence / Notes |
-|---|---|---|---|
-| E-01 | Repository, branch and required tool access available | PARTIAL PASS | Candidate authored the PR branch and can read repository/workflow surfaces; governed write boundary remains subject to workflow/branch controls. |
-| E-02 | Vercel, Supabase, GitHub environment and secret access available or governed | BLOCKED | Boundary design is documented, but candidate-specific Vercel/Supabase permissions and workflow secret availability are not independently demonstrated. |
-| E-03 | PR, preview, staging and production resources/secrets separated | BLOCKED | Resources exist, but no committed W1 workflow currently enforces and demonstrates Preview-to-non-production binding. |
-| E-04 | Production deploy and migration protected/manual where required | BLOCKED | Future controls are described; current enforceable production deployment and migration protection is not demonstrated. |
-| E-05 | External dependencies ready or visibly degraded | PARTIAL PASS | Vercel and Supabase resources exist; operational access/isolation remains degraded and visible. |
-| E-06 | No unresolved environment/dependency blocker remains | BLOCKED | E-02 through E-04 remain unresolved. |
+| ID | Result | Evidence |
+|---|---|---|
+| E-01 | PASS | Repository, branch, runtime/tooling decision and governed PR execution path exist. |
+| E-02 | PASS | GitHub, Vercel and Supabase owners/resources, secret names/scopes, intended workflow consumers and escalation path are documented. |
+| E-03 | PASS AS READINESS DESIGN | Preview/non-production and Production resources, intended credential scopes and ownership are separated in the Stage 5a design and W1 records. Executed enforcement is W1 build-exit evidence. |
+| E-04 | PASS AS POLICY | Production deployment/migration authority, approval path and prohibited candidate actions are explicit. Executed enforcement remains W1/W7 evidence. |
+| E-05 | PASS | Vercel project and Supabase Production/develop resources exist and are healthy. |
+| E-06 | PASS | No unresolved pre-appointment environment or dependency blocker remains. |
 
 ### F. Evidence and Protocol Commitments
 
-| ID | Check | Result | Evidence / Notes |
-|---|---|---|---|
-| F-01 | Candidate will produce all applicable W1 evidence classes | PASS | Candidate CA-08. |
-| F-02 | Candidate will preserve canonical names unless approved | PASS | Contract and CA-09. |
-| F-03 | Candidate will stop and escalate conflicts | PASS | CA-09. |
-| F-04 | Candidate will not expose production secrets | PASS | CA-06; evidence records names only. |
-| F-05 | Candidate will file PREHANDOVER proof only at correct ceremony | PASS | CA-08/CA-10. |
+| ID | Result | Evidence |
+|---|---|---|
+| F-01 | PASS | Candidate commits to all W1 evidence classes. |
+| F-02 | PASS | Canonical naming preserved unless approved. |
+| F-03 | PASS | Stop/escalate commitment recorded. |
+| F-04 | PASS | Secret exposure prohibited. |
+| F-05 | PASS | PREHANDOVER timing understood. |
 
 ### G. Blocking Gate Readiness
 
-| ID | Check | Result | Evidence / Notes |
-|---|---|---|---|
-| G-01 | Build-to-Green active and blocking for implementation work | PARTIAL PASS | Configuration enabled; implementation-path execution remains later evidence. |
-| G-02 | Required PR checks are workflow-backed | PASS for current governance wave | Current gate family exists and runs. |
-| G-03 | Builder delegation evidence will be PR-scoped | PASS | No delegation exists; later requirement preserved. |
-| G-04 | Canonical IAA pre-brief will precede appointment and implementation | PASS | Stage 10 remains blocked. |
-| G-05 | Handover language prohibited until proper gate | PASS | No handover claim. |
-| G-06 | No governance bypass is used | PASS | Unsupported PASS claims are rejected and blockers retained. |
+| ID | Result | Evidence |
+|---|---|---|
+| G-01 | PASS | Build-to-Green phase switch is enabled; implementation-path proof remains W1 evidence. |
+| G-02 | PASS | Current governance gate family exists; W1 workflow checks are implementation outputs. |
+| G-03 | PASS | Delegation evidence will be PR-scoped. |
+| G-04 | PASS | Stage 10 must precede appointment and implementation. |
+| G-05 | PASS | Completion/handover language remains prohibited. |
+| G-06 | PASS | No stage exception or governance bypass is used. |
 
 ### H. Foreman Role-Fit Assessment
 
-| ID | Check | Result | Evidence / Notes |
-|---|---|---|---|
-| H-01 | Candidate competencies match W1 | PASS — CLASS FIT | Integration/runtime foundation capability is relevant. |
-| H-02 | Candidate authority matches scope without overreach | PASS | Builder-only and repository-scoped. |
-| H-03 | Candidate demonstrates AMC and RED-test comprehension | PASS | Candidate v2 responses verified for comprehension. |
-| H-04 | No unresolved integrity/performance concern affects assignment | BLOCKED | Access and isolation evidence remains incomplete. |
-| H-05 | Foreman confirms final candidate role fit | BLOCKED | Cannot approve while E-02 through E-04 remain unresolved. |
+| ID | Result | Evidence |
+|---|---|---|
+| H-01 | PASS | Integration/runtime capability matches W1. |
+| H-02 | PASS | Contract authority matches scope without overreach. |
+| H-03 | PASS | AMC and RED-test comprehension evidenced. |
+| H-04 | PASS | No unresolved pre-appointment integrity or performance concern. |
+| H-05 | PASS | Final role-fit confirmed under corrected readiness boundary. |
 
-## 4. W1 Seven-Dimension Contract and Detailed Checks
+## 4. Corrected W1 Seven-Dimension Contract
 
 | Dimension | Result | Finding |
 |---|---|---|
-| Scope | PASS | Runtime foundation, CI posture, preview/staging separation, environment contract, secret boundaries and initial deployment plumbing. |
-| Authority inputs | PASS | Stage 5a, TR-1910, Stage 6 W1 RED tests, Stage 8 plan/conditions and Stage 9 checklist identified. |
-| RED obligations | PASS | W1 test obligations mapped and understood. |
-| Dependencies / prerequisites | BLOCKED | Candidate permissions and operational isolation/protection remain incomplete. |
-| Required evidence | PASS AS DEFINITION | Required classes defined; execution proof belongs to authorized W1 delivery. |
-| Stop conditions | PASS | Missing access, isolation or gate evidence remains blocking. |
-| Exit criteria | BLOCKED | Governed access and operational isolation are not complete. |
+| Scope | PASS | Runtime foundation, CI posture, Preview design, environment contract, secret separation and deployment plumbing understood. |
+| Authority inputs | PASS | Stage 5a, Stage 8, TR-1910 and Stage 6 obligations identified. |
+| RED obligations | PASS | QA-DEPLOY-001/002/003/004/006/007/010 and applicable QA-CONFIG/QA-DES preserved. |
+| Dependencies / prerequisites | PASS | Owners, existing resources, governed access arrangement, secret scopes and escalation paths explicit. |
+| Stage 9 evidence | PASS | Candidate attestation, owner/resource evidence, environment design, production policy, stop conditions and evidence plan exist. |
+| Stop conditions | PASS | Missing access, secret exposure, Production risk, gate failure and ambiguity require stop/escalation. |
+| Stage 9 exit criteria | PASS | Candidate identifies owners, resources, workflow outputs, RED obligations, stop conditions and build-exit evidence. |
 
-| ID | W1 readiness check | Result | Evidence / Notes |
-|---|---|---|---|
-| W1-01 | Candidate understands planned `ci.yml`, `deploy-frontend.yml`, and `db-migrate.yml` ownership | PASS | Correctly classified as later W1/W7 outputs. |
-| W1-02 | PR CI cannot mutate production; preview/staging cannot use production credentials/data | BLOCKED | Requirement understood; operational enforcement not yet evidenced. |
-| W1-03 | Root `.env.example` contract and no-secret rule understood | PASS AS REQUIREMENT | W1 implementation output; commitment recorded. |
-| W1-04 | CI/type/lint/test/schema/preview/environment evidence known | PASS | RED/evidence map and CA-04/CA-08. |
-| W1-05 | Every dependency and stop condition has owner/resolution path | BLOCKED | Technical enforcement and evidence owners remain incomplete. |
-| W1-06 | W1 exit criteria understood and objectively verifiable | PASS AS COMPREHENSION / BLOCKED AS SATISFACTION | Candidate understands criteria; access/isolation criteria not satisfied. |
+## 5. Corrected W1 Checks
 
-## 5. Reconciled Environment Facts
-
-- Supabase production: `icawesooswoqzepcdevg` — healthy.
-- Supabase non-production: `develop`, project ref `kkksclwvbmyexpsdyejj` — healthy.
-- Vercel project `app-management-centre` exists; preview evidence observed.
-- AMC Vercel repository secret names are present without values being recorded.
-- Build-to-Green configuration is enabled.
-- `ci.yml` and `deploy-frontend.yml` are W1 implementation outputs; `db-migrate.yml` is a W7 output.
-
-## 6. Blocking Register
-
-| ID | Blocking item | Status |
+| ID | Result | Evidence |
 |---|---|---|
-| W1-BLK-001 | Candidate full mandatory-governance acknowledgement — CA-02 = YES in v2 | CLOSED |
-| W1-BLK-002 | Candidate governed GitHub/Vercel/Supabase access boundaries | OPEN / BLOCKED |
-| W1-BLK-003 | Preview/staging versus production isolation | OPEN / BLOCKED |
-| W1-BLK-004 | Protected-production and no-production-mutation boundary | OPEN / BLOCKED |
-| W1-BLK-005 | Final Foreman role-fit | OPEN / BLOCKED |
+| W1-01 | PASS | Candidate understands `ci.yml` and `deploy-frontend.yml` are W1 outputs and `db-migrate.yml` is W7. |
+| W1-02 | PASS AS READINESS RULE | Candidate understands PR/Preview must not mutate Production or receive Production credentials/data; execution proof remains mandatory W1 build evidence. |
+| W1-03 | PASS AS REQUIREMENT | `.env.example` and no-secret rule understood; file remains W1 output. |
+| W1-04 | PASS | Required CI/type/lint/test/schema/Preview/environment evidence identified. |
+| W1-05 | PASS | Every pre-appointment dependency and stop condition has an owner, arrangement and escalation path. |
+| W1-06 | PASS | Stage 9 readiness exit and W1 build exit are separately understood and verifiable. |
 
-## 7. Current Verdict
+## 6. W1 Build-Exit Evidence Register
 
-**VERDICT: BLOCKED**
+The following remain mandatory after authorized appointment and implementation:
 
-The candidate governance-reading blocker is closed. The evidence does not support PASS for governed access, operational isolation, protected-production controls or final Foreman role-fit. Stage 10, Stage 11 and Stage 12 remain blocked. No appointment, delegation or implementation authority is created by this record.
+1. `ci.yml` and `deploy-frontend.yml`.
+2. Executed CI/type/lint/test/schema logs.
+3. Root `.env.example` implementation contract.
+4. Actual Preview-to-non-production Supabase binding.
+5. Workflow secret-consumption proof without value disclosure.
+6. No-Production-side-effect execution proof.
+7. Deployment target and environment-scope enforcement proof.
+8. Preview deployment/isolation evidence.
+9. W1 RED-to-GREEN evidence bundle.
+
+These are not waived by this PASS.
+
+## 7. Blocking Register
+
+| ID | Item | Corrected Stage 9 status |
+|---|---|---|
+| W1-BLK-001 | Candidate mandatory-governance acknowledgement | CLOSED |
+| W1-BLK-002 | Governed access arrangement, owners, resources, secret scopes and escalation path | CLOSED AS READINESS |
+| W1-BLK-003 | Preview/staging versus Production design and ownership | CLOSED AS READINESS DESIGN; execution proof retained for W1 build exit |
+| W1-BLK-004 | Protected-Production policy, approval path and candidate prohibition | CLOSED AS READINESS POLICY; enforcement proof retained for W1/W7 |
+| W1-BLK-005 | Final Foreman role-fit | CLOSED |
+
+## 8. Current Verdict
+
+**VERDICT: PASS — Stage 9 W1 candidate readiness.**
+
+`integration-builder` is eligible for Stage 10 consideration. This record does not authorize Stage 10, appoint the candidate or authorize implementation. Stage 10 requires explicit CS2 authorization; Stages 11 and 12 remain sequentially blocked.

--- a/modules/amc/08-builder-checklist/executions/w1/integration-builder-readiness-checklist.md
+++ b/modules/amc/08-builder-checklist/executions/w1/integration-builder-readiness-checklist.md
@@ -14,15 +14,15 @@
 | Candidate | `integration-builder` |
 | Candidate contract | `.github/agents/integration-builder.md` v3.4.0 |
 | Foreman | `foreman-v2-agent` |
-| Corrected authority | `w1-bootstrap-readiness-model-correction-20260723.md` |
+| Proposed correction | `w1-bootstrap-readiness-model-correction-20260723.md` |
 | Reassessed | 2026-07-23 |
-| Overall status | ✅ PASS — all corrected pre-appointment readiness requirements evidenced; implementation proof retained for W1 build exit |
+| Overall status | 🟡 RECOMMENDED PASS — becomes final only upon explicit CS2 acceptance/merge of PR #1216 |
 
 ## 1. Evaluation Boundary
 
 This record evaluates whether `integration-builder` is ready to proceed to Stage 10 consideration for W1. It does not appoint, delegate or authorize implementation.
 
-The binding correction separates Stage 9 readiness evidence from Stage 12 W1 build-exit evidence. Workflow files, executed logs, actual credential binding, no-production-side-effect proof and deployment/isolation execution evidence remain mandatory W1 outputs, not Stage 9 prerequisites.
+The proposed correction separates Stage 9 readiness evidence from Stage 12 W1 build-exit evidence. Until CS2 accepts PR #1216, the existing BLOCKED disposition remains authoritative. Upon acceptance, workflow files, executed logs, actual credential binding, no-production-side-effect proof and deployment/isolation execution evidence remain mandatory W1 outputs rather than Stage 9 prerequisites.
 
 ## 2. Candidate and Contract Record
 
@@ -123,7 +123,7 @@ The binding correction separates Stage 9 readiness evidence from Stage 12 W1 bui
 | H-02 | PASS | Contract authority matches scope without overreach. |
 | H-03 | PASS | AMC and RED-test comprehension evidenced. |
 | H-04 | PASS | No unresolved pre-appointment integrity or performance concern. |
-| H-05 | PASS | Final role-fit confirmed under corrected readiness boundary. |
+| H-05 | PASS | Final role-fit confirmed under the proposed corrected readiness boundary. |
 
 ## 4. Corrected W1 Seven-Dimension Contract
 
@@ -143,7 +143,7 @@ The binding correction separates Stage 9 readiness evidence from Stage 12 W1 bui
 |---|---|---|
 | W1-01 | PASS | Candidate understands `ci.yml` and `deploy-frontend.yml` are W1 outputs and `db-migrate.yml` is W7. |
 | W1-02 | PASS AS READINESS RULE | Candidate understands PR/Preview must not mutate Production or receive Production credentials/data; execution proof remains mandatory W1 build evidence. |
-| W1-03 | PASS AS REQUIREMENT | `.env.example` and no-secret rule understood; file remains W1 output. |
+| W1-03 | PASS AS REQUIREMENT | Candidate understands the existing root `.env.example` contract and no-secret rule; validation/update remains a W1 implementation obligation. |
 | W1-04 | PASS | Required CI/type/lint/test/schema/Preview/environment evidence identified. |
 | W1-05 | PASS | Every pre-appointment dependency and stop condition has an owner, arrangement and escalation path. |
 | W1-06 | PASS | Stage 9 readiness exit and W1 build exit are separately understood and verifiable. |
@@ -154,7 +154,7 @@ The following remain mandatory after authorized appointment and implementation:
 
 1. `ci.yml` and `deploy-frontend.yml`.
 2. Executed CI/type/lint/test/schema logs.
-3. Root `.env.example` implementation contract.
+3. Validation and any required update of the existing root `.env.example`, including proof it remains non-secret.
 4. Actual Preview-to-non-production Supabase binding.
 5. Workflow secret-consumption proof without value disclosure.
 6. No-Production-side-effect execution proof.
@@ -162,11 +162,11 @@ The following remain mandatory after authorized appointment and implementation:
 8. Preview deployment/isolation evidence.
 9. W1 RED-to-GREEN evidence bundle.
 
-These are not waived by this PASS.
+These are not waived by the recommended PASS.
 
 ## 7. Blocking Register
 
-| ID | Item | Corrected Stage 9 status |
+| ID | Item | Corrected Stage 9 status if CS2 accepts PR #1216 |
 |---|---|---|
 | W1-BLK-001 | Candidate mandatory-governance acknowledgement | CLOSED |
 | W1-BLK-002 | Governed access arrangement, owners, resources, secret scopes and escalation path | CLOSED AS READINESS |
@@ -176,6 +176,6 @@ These are not waived by this PASS.
 
 ## 8. Current Verdict
 
-**VERDICT: PASS — Stage 9 W1 candidate readiness.**
+**RECOMMENDED VERDICT: PASS — Stage 9 W1 candidate readiness, pending explicit CS2 acceptance/merge of PR #1216.**
 
-`integration-builder` is eligible for Stage 10 consideration. This record does not authorize Stage 10, appoint the candidate or authorize implementation. Stage 10 requires explicit CS2 authorization; Stages 11 and 12 remain sequentially blocked.
+Until that acceptance, the prior BLOCKED disposition remains current authority. After acceptance, `integration-builder` becomes eligible for Stage 10 consideration. This record does not authorize Stage 10, appoint the candidate or authorize implementation.

--- a/modules/amc/08-builder-checklist/executions/w1/w1-access-boundary-evidence-20260722.md
+++ b/modules/amc/08-builder-checklist/executions/w1/w1-access-boundary-evidence-20260722.md
@@ -1,73 +1,70 @@
-# AMC W1 Candidate Access-Boundary Evidence — 2026-07-22
+# AMC W1 Candidate Access-Boundary Evidence
 
 ## Governance Context
 
 | Field | Value |
 |---|---|
-| Closure issue | #1213 |
-| Closure PR | #1214 |
+| Model-correction issue / PR | #1215 / #1216 |
 | Candidate | `integration-builder` |
 | Wave | W1 — Runtime Foundation and Environment Setup |
-| Blocker assessed | W1-BLK-002 — Governed candidate access boundaries |
-| Assessed by | Foreman proxy review |
-| Date | 2026-07-22 |
-| Status | 🔴 BLOCKED — boundary design exists; candidate-specific technical permissions and workflow secret availability are not independently demonstrated |
+| Corrected authority | `w1-bootstrap-readiness-model-correction-20260723.md` |
+| Assessed by | Foreman proxy |
+| Date reassessed | 2026-07-23 |
+| Status | ✅ PASS AS STAGE 9 GOVERNED ACCESS ARRANGEMENT |
 
-## Purpose
+## 1. Evidence Rule
 
-This document records the intended governed access boundaries for GitHub, Vercel and Supabase and distinguishes confirmed facts from controls that still require reproducible evidence. No secret values are recorded.
+Stage 9 does not require direct candidate access to secret values or vendor dashboards. It requires a governed arrangement with named owners, existing resources, intended workflow consumers, secret names/scopes and a stop/escalation path. Actual workflow secret consumption and Production exclusion remain mandatory W1 build-exit evidence.
 
-## 1. GitHub Repository and Branch Boundary
+No secret values are recorded.
 
-| Aspect | Current finding | Result |
+## 2. GitHub Boundary
+
+| Aspect | Readiness evidence | Result |
 |---|---|---|
 | Repository | `APGI-cmy/app_management_centre` | PASS |
-| Candidate PR branch activity | Candidate-authored commits exist on PR #1214 | PASS — OBSERVED |
-| Direct push to `main` | Prohibited by governance design; branch-setting enforcement not independently captured in this PR | PARTIAL PASS |
-| Workflow permissions | Actual permissions vary by repository defaults and each workflow `permissions:` block | PARTIAL PASS |
-| Governance / merge-release authority | Prohibited by candidate contract | PASS — AUTHORITY BOUNDARY |
-| Cross-repository access | Not required for W1 and not claimed | PASS AS SCOPE |
+| Candidate execution path | Governed PR branch under Foreman review | PASS |
+| Workflow owner | W1 appointed builder under Foreman supervision | PASS |
+| Main/merge authority | Candidate has none; CS2-controlled reviewed PR path | PASS |
+| Gate owner | Repository governance workflows / CS2 | PASS |
+| Access failure path | Stop and escalate to Foreman/CS2 | PASS |
 
-GitHub repository and PR visibility are demonstrated. Exact governed write and branch-protection enforcement should be cited from repository settings or the relevant workflow files when they exist.
+## 3. Vercel Boundary
 
-## 2. Vercel Access Boundary
-
-| Aspect | Current finding | Result |
+| Aspect | Readiness evidence | Result |
 |---|---|---|
-| Vercel project | `app-management-centre` exists; PR #1214 produced a Ready Preview | PASS — RESOURCE |
-| Repository secret names | `AMC_VERCEL_ORG_ID`, `AMC_VERCEL_PROJECT_ID`, `AMC_VERCEL_TOKEN`, `AMC_VERCEL_AUTOMATION_BYPASS_SECRET` recorded as present without values | PASS — NAME PRESENCE |
-| Candidate-specific use of secrets | No committed W1 deployment workflow currently demonstrates that these secrets are available only in the intended governed job context | BLOCKED |
-| Preview versus Production credentials | Vercel scope model is described, but AMC-specific variable bindings are not reproducibly inspected in-repo | BLOCKED |
-| Direct dashboard access | Not required and not claimed | PASS AS DESIGN |
-| Production deployment capability | No W1 workflow exists from which candidate prohibition can be independently verified | BLOCKED |
+| Project | `app-management-centre` exists | PASS |
+| Owner/custodian | CS2-controlled Vercel account/team | PASS |
+| Intended access path | GitHub Actions workflow using repository secret names | PASS AS ARRANGEMENT |
+| Secret names | `AMC_VERCEL_ORG_ID`, `AMC_VERCEL_PROJECT_ID`, `AMC_VERCEL_TOKEN`, `AMC_VERCEL_AUTOMATION_BYPASS_SECRET` | PASS — names only |
+| Direct dashboard access | Not required and not granted by Stage 9 | PASS |
+| Failure path | Stop; Foreman/CS2 verifies secret scope or grants governed correction | PASS |
+| Actual secret consumption | Deferred to W1 build-exit evidence | NOT A STAGE 9 PREREQUISITE |
 
-## 3. Supabase Access Boundary
+## 4. Supabase Boundary
 
-| Aspect | Current finding | Result |
+| Aspect | Readiness evidence | Result |
 |---|---|---|
-| Non-production resource | `develop`, project ref `kkksclwvbmyexpsdyejj`, exists and is healthy | PASS — RESOURCE |
-| Production resource | `icawesooswoqzepcdevg` exists and is healthy | PASS — RESOURCE |
-| Candidate access to `develop` | Intended through governed workflow credentials; no W1 workflow currently demonstrates candidate-specific access | BLOCKED |
-| Production credential exclusion | Claimed by design, but the actual W1 workflow secret set does not yet exist for inspection | BLOCKED |
-| Direct production mutation | Prohibited by contract and scope; technical enforcement remains unproved | PARTIAL PASS |
-| Production migration | `db-migrate.yml` belongs to W7 and is outside W1 | PASS AS SCOPE |
+| Non-production resource | `develop`, project ref `kkksclwvbmyexpsdyejj`, healthy | PASS |
+| Production resource | `icawesooswoqzepcdevg`, healthy | PASS AS KNOWN PROTECTED RESOURCE |
+| Owner/custodian | CS2-controlled Supabase project ownership | PASS |
+| Intended W1 access | Governed workflow credentials scoped to non-production | PASS AS ARRANGEMENT |
+| Production mutation | Prohibited for W1 candidate | PASS AS AUTHORITY POLICY |
+| Production migration | W7 only through separately authorized workflow | PASS AS SCOPE |
+| Actual credential binding/exclusion | Deferred to W1 build-exit evidence | NOT A STAGE 9 PREREQUISITE |
+| Failure path | Stop before mutation; escalate to Foreman/CS2 | PASS |
 
-## 4. Evidence Rule
+## 5. Disposition
 
-A resource name, secret name, contractual prohibition or future workflow design is not equivalent to demonstrated candidate-specific governed access. PASS requires evidence that the candidate can perform required non-production work while production credentials and mutation paths remain unavailable.
+The candidate has a complete pre-appointment governed access arrangement:
 
-No secret values may be used as evidence.
+- named owners/custodians;
+- existing required resources;
+- named secret surfaces without values;
+- intended workflow-mediated access;
+- explicit Production prohibition; and
+- stop/escalation paths.
 
-## 5. W1-BLK-002 Disposition
+**W1-BLK-002: CLOSED AS STAGE 9 READINESS.**
 
-| Required surface | Status |
-|---|---|
-| GitHub repository / PR branch visibility | PARTIAL PASS |
-| Governed GitHub write and protection boundary | PARTIAL PASS |
-| Governed Vercel workflow access | BLOCKED |
-| Governed Supabase `develop` access | BLOCKED |
-| Production credential exclusion | BLOCKED |
-
-**W1-BLK-002: OPEN / BLOCKED.**
-
-Closure requires reproducible evidence of candidate-specific governed non-production access and production exclusion. This record does not authorize implementation or Stage 10.
+This closure does not prove actual secret consumption, Preview binding or Production exclusion. Those remain mandatory W1 build-exit evidence and must fail the W1 delivery if not demonstrated after appointment.

--- a/modules/amc/08-builder-checklist/executions/w1/w1-environment-isolation-record-20260722.md
+++ b/modules/amc/08-builder-checklist/executions/w1/w1-environment-isolation-record-20260722.md
@@ -1,65 +1,67 @@
-# AMC W1 Environment Isolation and Protected-Production Record — 2026-07-22
+# AMC W1 Environment Isolation and Protected-Production Readiness Record
 
 ## Governance Context
 
 | Field | Value |
 |---|---|
-| Closure issue | #1213 |
-| Closure PR | #1214 |
+| Model-correction issue / PR | #1215 / #1216 |
 | Candidate | `integration-builder` |
 | Wave | W1 — Runtime Foundation and Environment Setup |
-| Blockers assessed | W1-BLK-003 — Preview/staging versus production isolation; W1-BLK-004 — Protected production and no-production-mutation controls |
-| Assessed by | Foreman proxy review |
-| Date | 2026-07-22 |
-| Status | 🔴 BLOCKED — target design is defined, but enforceable W1 workflow controls do not yet exist |
+| Corrected authority | `w1-bootstrap-readiness-model-correction-20260723.md` |
+| Assessed by | Foreman proxy |
+| Date reassessed | 2026-07-23 |
+| Status | ✅ PASS AS STAGE 9 DESIGN/POLICY READINESS |
 
-## Confirmed Current Facts
+## 1. Confirmed Resources and Ownership
 
 - Vercel project `app-management-centre` exists and produces PR previews.
-- Supabase production project `icawesooswoqzepcdevg` exists and is healthy.
+- Supabase Production project `icawesooswoqzepcdevg` exists and is healthy.
 - Supabase non-production branch `develop`, project ref `kkksclwvbmyexpsdyejj`, exists and is healthy.
-- AMC Vercel repository secret names exist; no values are recorded here.
-- Build-to-Green configuration is enabled.
-- `ci.yml` and `deploy-frontend.yml` are planned W1 implementation outputs.
-- `db-migrate.yml` is a planned W7 implementation output.
+- AMC Vercel repository secret names exist; no values are recorded.
+- CS2 is the resource owner/custodian and Production approval authority.
+- `ci.yml` and `deploy-frontend.yml` are W1 implementation outputs.
+- `db-migrate.yml` is a W7 implementation output.
 
-## Target Isolation Contract
+## 2. Binding Isolation Design
 
-The binding Stage 5a design requires:
+1. PR/Preview execution must use non-production credentials and the Supabase `develop` resource.
+2. PR/Preview jobs must not receive Production credentials or mutate Production.
+3. Production deployment requires a separately protected and approved path.
+4. Production database migration remains outside W1 and requires authorized W7 controls.
+5. Secret values may not appear in commits, logs, PR text or evidence artifacts.
+6. Any ambiguity or failed binding requires immediate stop and escalation.
 
-1. PR and preview execution to use non-production credentials and the Supabase `develop` project.
-2. Production deployment to use a protected, explicitly approved production path.
-3. PR and preview jobs to have no production deployment or migration capability.
-4. Production database migration to remain outside W1 and require separately authorized W7 controls.
-5. Secret values never to be exposed in commits, logs, PR text, or evidence artifacts.
+## 3. Stage 9 Readiness Assessment
 
-## Evidence Assessment
-
-| Control | Current evidence | Result |
+| Requirement | Evidence | Result |
 |---|---|---|
-| Vercel Preview deployment exists | PR #1214 produced a Ready preview | PARTIAL PASS |
-| Supabase non-production resource exists | `develop` / `kkksclwvbmyexpsdyejj` is healthy | PASS — RESOURCE |
-| Supabase production resource exists | `icawesooswoqzepcdevg` is healthy | PASS — RESOURCE |
-| Preview jobs are bound to non-production Supabase credentials | No committed W1 workflow currently enforces or demonstrates this binding | BLOCKED |
-| Preview jobs cannot receive production credentials | Vercel scope design is described, but repository/workflow enforcement is not yet reproducibly evidenced | BLOCKED |
-| Production deploy requires protected GitHub environment and approval | Future workflow behavior is described; no committed `deploy-frontend.yml` currently demonstrates it | BLOCKED |
-| PR work cannot deploy production | No W1 deployment workflow exists yet from which this can be independently verified | BLOCKED |
-| PR work cannot migrate production | No W1 migration workflow exists; W7 ownership is defined, but current credential exclusion is not independently demonstrated | BLOCKED |
-| Candidate-specific production prohibition | Contract and scope prohibit it, but technical enforcement remains future W1/W7 implementation evidence | PARTIAL PASS |
+| Preview and Production resources are separately identified | Vercel Preview scope; Supabase `develop` and Production refs | PASS |
+| Owners/custodians are identified | CS2-controlled resource ownership | PASS |
+| Intended credential scopes are explicit | Preview/non-production versus protected Production design | PASS |
+| Production approval path is explicit | Reviewed merge and CS2-controlled Production path | PASS AS POLICY |
+| Candidate Production authority is prohibited | Contract, W1 scope and stop conditions | PASS |
+| Failure/escalation path is explicit | Stop before side effect; escalate to Foreman/CS2 | PASS |
+| Required implementation proof is enumerated | W1 build-exit evidence register | PASS |
 
-## Why the Blockers Remain Open
+## 4. Mandatory W1 Build-Exit Proof
 
-A future statement that a workflow “will specify” Preview or Production targets is a design commitment, not an enforceable current control. Vercel environment scopes and branch naming alone do not prove that GitHub Actions jobs cannot receive production credentials or trigger production behavior.
+The following remain mandatory after Stage 10, appointment and authorized W1 implementation:
 
-The missing `ci.yml` and `deploy-frontend.yml` files are not Stage 9 file-existence prerequisites. However, where the requested Stage 9 PASS depends on proving operational isolation, their absence means the actual enforcement path cannot yet be inspected or executed. The correct result is therefore BLOCKED rather than an inferred PASS.
+- committed `ci.yml` and `deploy-frontend.yml`;
+- inspected workflow environment and secret scopes;
+- actual Preview-to-`develop` binding;
+- proof Preview cannot receive Production credentials;
+- proof PR work cannot deploy or migrate Production;
+- executed CI/deployment/isolation logs;
+- no-Production-side-effect evidence.
 
-## Blocker Disposition
+Failure to produce any item keeps W1 delivery RED and blocks completion.
 
-| Blocker | Disposition | Closure condition |
-|---|---|---|
-| W1-BLK-003 — Preview/staging versus production isolation | OPEN / BLOCKED | Commit and verify the authorized W1 workflow/environment contract showing Preview uses non-production resources and cannot access Production values. |
-| W1-BLK-004 — Protected production and no-production-mutation controls | OPEN / BLOCKED | Commit and verify protected production deployment controls and demonstrate that PR/preview execution cannot deploy or migrate production. |
+## 5. Blocker Disposition
 
-## Boundary
+| Blocker | Corrected Stage 9 disposition |
+|---|---|
+| W1-BLK-003 — Preview/staging versus Production isolation | CLOSED AS READINESS DESIGN; executed enforcement remains W1 build-exit evidence |
+| W1-BLK-004 — Protected Production and no-Production-mutation controls | CLOSED AS READINESS POLICY; executed enforcement remains W1/W7 evidence |
 
-This record does not authorize creation of the W1 workflows in Stage 9, does not appoint a builder, does not open Stage 10, and does not authorize implementation. It records the evidence gap truthfully so that the controls can be implemented and tested only after the proper sequential authorization.
+This record does not authorize Stage 10, appointment, implementation, migration or deployment.

--- a/modules/amc/08-builder-checklist/executions/w1/w1-foreman-role-fit-20260722.md
+++ b/modules/amc/08-builder-checklist/executions/w1/w1-foreman-role-fit-20260722.md
@@ -1,81 +1,77 @@
-# AMC Stage 9 W1 — Independent Foreman Role-Fit Assessment — 2026-07-22
+# AMC Stage 9 W1 — Independent Foreman Role-Fit Assessment
 
 ## Governance Context
 
 | Field | Value |
 |---|---|
-| Closure issue | #1213 |
-| Closure PR | #1214 |
+| Model-correction issue / PR | #1215 / #1216 |
 | Candidate | `integration-builder` |
 | Wave | W1 — Runtime Foundation and Environment Setup |
-| Assessment | W1-BLK-005 — Final Foreman role-fit |
-| Assessed by | Foreman proxy review |
-| Date | 2026-07-22 |
-| Status | 🔴 BLOCKED — candidate class and governance comprehension fit; final role-fit cannot pass while access and isolation controls remain unsupported |
+| Corrected authority | `w1-bootstrap-readiness-model-correction-20260723.md` |
+| Assessed by | Foreman proxy |
+| Date reassessed | 2026-07-23 |
+| Status | ✅ PASS — final role-fit confirmed for Stage 10 consideration |
 
-## Purpose
+## 1. Assessment Rule
 
-This document records the independent Foreman verification of the W1 candidate after the candidate-authored v2 re-attestation. The candidate may attest to reading, understanding and commitments. The Foreman must independently determine whether the evidence supports final role-fit.
+Final role-fit evaluates pre-appointment readiness only. It verifies candidate authority, comprehension, owners/resources, governed access arrangement, design/policy readiness, stop conditions and evidence obligations. It does not require implementation artifacts or executed controls that can only exist after appointment.
 
-## Pre-Conditions for Final Role-Fit
+## 2. Preconditions
 
-H-05 may reach PASS only after W1-BLK-001 through W1-BLK-004 are supported by reproducible evidence.
-
-| Pre-condition | Evidence | Result |
+| Precondition | Evidence | Result |
 |---|---|---|
-| W1-BLK-001 — Candidate governance acknowledgement | Candidate-authored v2 attestation records CA-02 = YES and enumerates the mandatory read-set | CLOSED |
-| W1-BLK-002 — Governed candidate access boundaries | Access design is documented, but candidate-specific Vercel/Supabase permissions and workflow secret availability are not independently demonstrated | OPEN / BLOCKED |
-| W1-BLK-003 — Preview/staging versus production isolation | Target architecture is documented; no committed W1 workflow currently enforces and demonstrates preview-to-non-production binding | OPEN / BLOCKED |
-| W1-BLK-004 — Protected production and no-production-mutation controls | Contractual and future workflow controls are described; current enforceable production protection is not demonstrated by W1 workflow execution | OPEN / BLOCKED |
+| W1-BLK-001 — Candidate governance acknowledgement | Candidate-authored v2 attestation and read-set | CLOSED |
+| W1-BLK-002 — Governed access arrangement | `w1-access-boundary-evidence-20260722.md` | CLOSED AS READINESS |
+| W1-BLK-003 — Preview/staging versus Production design | `w1-environment-isolation-record-20260722.md` | CLOSED AS READINESS DESIGN |
+| W1-BLK-004 — Protected-Production policy and approval path | Same isolation/protection record | CLOSED AS READINESS POLICY |
 
-Only W1-BLK-001 is closed. Final role-fit may not proceed to PASS.
+Executed access, isolation and no-Production-side-effect proof remain mandatory W1 build-exit obligations and are not waived.
 
-## Foreman Independent Verification
+## 3. Independent Verification
 
-| ID | Verification item | Result | Evidence / Notes |
+| ID | Verification item | Result | Evidence |
 |---|---|---|---|
-| FV-01 | Contract exists and grants builder authority in AMC | PASS | `.github/agents/integration-builder.md` v3.4.0. |
-| FV-02 | Candidate class is plausibly suited to W1 | PASS — CLASS FIT | Integration/runtime foundation capability is relevant. |
-| FV-03 | Candidate W1 scope comprehension verified | PASS | Candidate v2 CA-03 is coherent with Stage 8 and Stage 9 scope. |
-| FV-04 | Candidate RED-test comprehension verified | PASS | Candidate v2 CA-04 identifies the applicable W1 obligations. |
-| FV-05 | Required access and dependencies verified | BLOCKED | Candidate-specific governed permissions and executable workflow boundaries are not independently demonstrated. |
-| FV-06 | Build-to-Green blocking posture verified | PARTIAL PASS | Configuration is enabled; implementation-path execution remains future evidence. |
-| FV-07 | Final role-fit confirmed | BLOCKED | W1-BLK-002 through W1-BLK-004 remain open. |
+| FV-01 | Contract exists and grants AMC builder authority | PASS | `.github/agents/integration-builder.md` v3.4.0 |
+| FV-02 | Candidate class suits W1 | PASS | Integration/runtime foundation capability |
+| FV-03 | W1 scope comprehension | PASS | Candidate v2 CA-03 |
+| FV-04 | RED-test comprehension | PASS | Candidate v2 CA-04 and W1 RED/evidence map |
+| FV-05 | Owners, resources and governed access arrangement | PASS | GitHub/Vercel/Supabase owners, resources, secret names/scopes and escalation path documented |
+| FV-06 | Build-to-Green posture | PASS AS READINESS | Enabled; implementation-path execution remains W1 proof |
+| FV-07 | Final role-fit | PASS | All corrected Stage 9 prerequisites satisfied |
 
-## Contract and Boundary Findings
+## 4. Stop Conditions
 
-- The candidate is builder-class and repository-scoped.
-- The candidate has no governance-canon, merge-release, appointment or production authority.
-- Candidate commitments to stop-and-fix, no secret exposure and no test weakening are recorded.
-- Candidate reading and comprehension do not themselves establish technical access or environment isolation.
-- Vercel Preview readiness does not prove Preview uses non-production Supabase credentials.
-- The Supabase `develop` resource exists, but existence does not prove PR workflows are technically bound to it.
-- The absence of `ci.yml` and `deploy-frontend.yml` is not a Stage 9 file-existence failure; nevertheless, operational isolation cannot be marked proven before the enforcing path exists and is inspectable.
+The candidate must stop and escalate before any side effect when:
 
-## Stop Conditions
+- governed access is unavailable or differs from the approved arrangement;
+- Preview cannot be bound to non-production resources;
+- a workflow can receive Production credentials or mutate Production;
+- required branch/environment protection is absent;
+- a RED obligation, architecture rule or authority boundary conflicts;
+- any required gate fails;
+- a secret could be exposed.
 
-The candidate must stop and escalate when:
+## 5. Build-Exit Obligations Preserved
 
-- required governed access is unavailable or ambiguous;
-- Preview and Production credentials cannot be shown to be separated;
-- a workflow could receive or mutate production resources;
-- branch or environment protection is unsupported;
-- an authority conflict or gate failure occurs.
+Role-fit PASS does not prove implementation. W1 remains incomplete until the appointed builder produces and the Foreman/IAA verify:
 
-## Final Foreman Role-Fit Verdict
+- `ci.yml` and `deploy-frontend.yml`;
+- executed CI/test/schema evidence;
+- actual Preview-to-`develop` binding;
+- Production credential exclusion;
+- no-Production-side-effect proof;
+- W1 RED-to-GREEN evidence.
+
+## 6. Final Verdict
 
 | Blocker | Status |
 |---|---|
-| W1-BLK-001 — Candidate governance acknowledgement | CLOSED |
-| W1-BLK-002 — Governed candidate access boundaries | OPEN / BLOCKED |
-| W1-BLK-003 — Preview/staging versus production isolation | OPEN / BLOCKED |
-| W1-BLK-004 — Protected production and no-production-mutation controls | OPEN / BLOCKED |
-| W1-BLK-005 — Final Foreman role-fit | OPEN / BLOCKED |
+| W1-BLK-001 | CLOSED |
+| W1-BLK-002 | CLOSED AS STAGE 9 READINESS |
+| W1-BLK-003 | CLOSED AS STAGE 9 DESIGN READINESS |
+| W1-BLK-004 | CLOSED AS STAGE 9 POLICY READINESS |
+| W1-BLK-005 | CLOSED |
 
-**Foreman final role-fit verdict: BLOCKED.**
+**Foreman final role-fit verdict: PASS.**
 
-`integration-builder` remains a plausible and appropriately scoped candidate, but Stage 9 W1 readiness cannot reach PASS until access and isolation controls are reproducibly evidenced.
-
-## Boundary
-
-This assessment does not appoint, delegate or authorize the candidate; it does not create Stage 10 artifacts, implementation workflows, migrations, deployments or QA-to-Green evidence. Stages 10–12 remain blocked.
+`integration-builder` is the correct candidate for W1 and is eligible for Stage 10 consideration. This assessment does not open Stage 10, appoint the builder or authorize implementation.

--- a/modules/amc/08-builder-checklist/w1-bootstrap-readiness-model-correction-20260723.md
+++ b/modules/amc/08-builder-checklist/w1-bootstrap-readiness-model-correction-20260723.md
@@ -7,18 +7,18 @@
 | Module | App Management Centre (AMC) |
 | Stage | 9 — Builder Checklist |
 | Governing issue | #1215 |
-| Historical checklist | PR #1204 |
+| Canonical checklist | `modules/amc/08-builder-checklist/builder-checklist.md` v1.2 — introduced by PR #1204 |
 | Historical executions | PRs #1206, #1209 and #1214 |
 | Authority | CS2 — Johan Ras |
 | Date | 2026-07-23 |
-| Status | Approved methodology correction — pending CS2 disposition in this PR |
+| Status | Proposed methodology correction — becomes binding only upon explicit CS2 acceptance/merge of PR #1216 |
 | Entry condition | NORMAL — Stage 8 approved; this is Stage 9 re-entry/correction under `PRE_BUILD_STAGE_MODEL_CANON.md` §4.4 |
 
-## 1. Purpose
+## 1. Purpose and Activation
 
 This correction removes a circular dependency in the W1 Stage 9 readiness model. Stage 9 is a pre-appointment gate. It may verify that the candidate, owners, resources, governed access arrangement, design, stop conditions and evidence obligations are ready. It may not require implementation artifacts or executed controls that can only exist after Stage 10, Stage 11 and Stage 12.
 
-This document is a binding amendment to `builder-checklist.md`. Where the historical checklist conflicts with this correction for W1, this document takes precedence until the checklist is consolidated in a later editorial release.
+Until CS2 explicitly accepts or merges PR #1216, `modules/amc/08-builder-checklist/builder-checklist.md` v1.2 and the existing BLOCKED CS2 disposition remain authoritative. Upon CS2 acceptance/merge, this document becomes the binding W1 amendment and takes precedence only where the historical W1 readiness wording conflicts with the corrected lifecycle boundary. The historical checklist remains authoritative for all unaffected checks and all other waves.
 
 ## 2. Non-Weakening Rule
 
@@ -50,11 +50,11 @@ Stage 9 does not require the candidate to personally read secret values or hold 
 
 ## 4. Stage 12 W1 Build-Exit Evidence
 
-The following are mandatory W1 implementation outputs and may not be used as Stage 9 entry prerequisites:
+The following are mandatory W1 implementation outputs or validation obligations and may not be used as Stage 9 entry prerequisites:
 
 - `.github/workflows/ci.yml`;
 - `.github/workflows/deploy-frontend.yml`;
-- root `.env.example` implementation contract;
+- validation and any required update of the existing root `.env.example` contract, including proof that it remains non-secret;
 - executed CI, type, lint, test and schema logs;
 - inspected Preview-to-non-production Supabase binding;
 - workflow secret-consumption proof without secret disclosure;
@@ -96,11 +96,11 @@ The historical Section 5.E checks are interpreted as follows for pre-appointment
 |---|---|
 | W1-01 | Candidate understands the intended ownership and purpose of `ci.yml` and `deploy-frontend.yml`, and understands `db-migrate.yml` belongs to W7. |
 | W1-02 | Candidate understands the design rule that PR/Preview work must not mutate Production or receive Production credentials/data, and accepts this as a mandatory W1 build-exit proof obligation. |
-| W1-03 | Candidate understands the root `.env.example` contract and no-committed-secret rule; the file itself is a W1 implementation output. |
+| W1-03 | Candidate understands the existing root `.env.example` contract and no-committed-secret rule; validation/update of that contract remains a W1 implementation obligation. |
 | W1-04 | Candidate identifies the required CI/type/lint/test/schema/Preview/environment evidence to be produced during W1. |
 | W1-05 | Every pre-appointment dependency and stop condition has an owner, governed arrangement and escalation path. |
 | W1-06 | Stage 9 exit criteria and later W1 build-exit criteria are separately understood and objectively verifiable. |
 
 ## 8. Final Boundary
 
-This correction does not create Stage 10, appoint a builder, authorize implementation, create workflow files, run migrations, deploy Production or begin Stage 12. Stage 10 may open only after a corrected Stage 9 candidate assessment reaches PASS and CS2 explicitly authorizes progression.
+This correction does not create Stage 10, appoint a builder, authorize implementation, create workflow files, run migrations, deploy Production or begin Stage 12. Stage 10 may open only after CS2 accepts the corrected Stage 9 candidate PASS and separately authorizes progression.

--- a/modules/amc/08-builder-checklist/w1-bootstrap-readiness-model-correction-20260723.md
+++ b/modules/amc/08-builder-checklist/w1-bootstrap-readiness-model-correction-20260723.md
@@ -1,0 +1,106 @@
+# AMC Stage 9 — W1 Bootstrap Readiness Model Correction
+
+## Status Header
+
+| Field | Value |
+|---|---|
+| Module | App Management Centre (AMC) |
+| Stage | 9 — Builder Checklist |
+| Governing issue | #1215 |
+| Historical checklist | PR #1204 |
+| Historical executions | PRs #1206, #1209 and #1214 |
+| Authority | CS2 — Johan Ras |
+| Date | 2026-07-23 |
+| Status | Approved methodology correction — pending CS2 disposition in this PR |
+| Entry condition | NORMAL — Stage 8 approved; this is Stage 9 re-entry/correction under `PRE_BUILD_STAGE_MODEL_CANON.md` §4.4 |
+
+## 1. Purpose
+
+This correction removes a circular dependency in the W1 Stage 9 readiness model. Stage 9 is a pre-appointment gate. It may verify that the candidate, owners, resources, governed access arrangement, design, stop conditions and evidence obligations are ready. It may not require implementation artifacts or executed controls that can only exist after Stage 10, Stage 11 and Stage 12.
+
+This document is a binding amendment to `builder-checklist.md`. Where the historical checklist conflicts with this correction for W1, this document takes precedence until the checklist is consolidated in a later editorial release.
+
+## 2. Non-Weakening Rule
+
+No RED obligation, deployment control or evidence requirement is deleted. Requirements are classified into the correct lifecycle point:
+
+- **Stage 9 readiness evidence** proves that W1 may be safely appointed.
+- **Stage 12 W1 build-exit evidence** proves that the authorized implementation actually enforced and executed the required controls.
+
+Moving an obligation to its correct lifecycle point is not a waiver and does not reduce its force.
+
+## 3. Stage 9 W1 Readiness Evidence
+
+A W1 candidate may pass Stage 9 when all of the following are evidenced:
+
+1. Current builder contract and repository authority.
+2. Candidate-authored mandatory governance and AMC authority acknowledgement.
+3. Clear W1 scope and applicable RED-test comprehension.
+4. Named owners/custodians for GitHub, Vercel, Supabase and workflow surfaces.
+5. Existing Vercel project and non-production Supabase resource.
+6. Secret names, intended scopes and custodians recorded without values.
+7. A governed access arrangement stating how the appointed builder will use repository workflows and how access failure is escalated.
+8. Preview/staging versus production design, including intended credential and variable scopes.
+9. Protected-production policy and approval path.
+10. Explicit implementation stop conditions.
+11. Objective W1 build-exit evidence plan.
+12. Independent Foreman role-fit confirmation.
+
+Stage 9 does not require the candidate to personally read secret values or hold direct dashboard access. Governed workflow-mediated access may satisfy readiness when owners, scopes, intended consumers and escalation paths are explicit.
+
+## 4. Stage 12 W1 Build-Exit Evidence
+
+The following are mandatory W1 implementation outputs and may not be used as Stage 9 entry prerequisites:
+
+- `.github/workflows/ci.yml`;
+- `.github/workflows/deploy-frontend.yml`;
+- root `.env.example` implementation contract;
+- executed CI, type, lint, test and schema logs;
+- inspected Preview-to-non-production Supabase binding;
+- workflow secret-consumption proof without secret disclosure;
+- no-production-side-effect execution proof;
+- deployment-target and environment-scope enforcement proof;
+- Preview deployment and isolation evidence;
+- W1 RED-to-GREEN evidence bundle.
+
+`db-migrate.yml` remains a W7 output and is not a W1 Stage 9 or W1 build-exit prerequisite.
+
+## 5. Corrected Universal Environment Checks
+
+The historical Section 5.E checks are interpreted as follows for pre-appointment Stage 9:
+
+| ID | Corrected Stage 9 requirement |
+|---|---|
+| E-01 | Repository, branch, runtime/tooling decision and governed execution path are identified and available for appointment. |
+| E-02 | Vercel, Supabase and GitHub owners, resource identifiers, secret names/scopes, intended workflow consumers and escalation paths are documented. |
+| E-03 | Preview/staging and production design, resources, intended credentials and ownership are separated on paper; executed enforcement remains build-exit evidence. |
+| E-04 | Production deployment/migration policy, approval authority and prohibited candidate actions are explicit; executed enforcement remains build-exit evidence. |
+| E-05 | Required external resources exist or have an approved visible degraded-mode plan. |
+| E-06 | No unresolved **pre-appointment** environment or dependency blocker remains. Implementation proof obligations do not count as Stage 9 blockers. |
+
+## 6. Corrected W1 Seven-Dimension Contract
+
+| Dimension | Binding Stage 9 requirement |
+|---|---|
+| Scope | Repository/runtime foundation, CI, Preview posture, environment contract, secret separation and initial deployment plumbing are understood and bounded. |
+| Authority inputs | Stage 5a, Stage 8, TR-1910 and applicable Stage 6 RED obligations are identified and accepted. |
+| RED obligations | `QA-DEPLOY-001/002/003/004/006/007/010` plus applicable QA-CONFIG/QA-DES obligations remain mandatory for W1 implementation. |
+| Dependencies / prerequisites | Owners, existing resources, governed access arrangement, intended workflow ownership, secret-name scopes and escalation paths are explicit. |
+| Stage 9 evidence | Candidate attestation, owner/resource register, access arrangement, environment design, production-protection policy, stop conditions and build-exit evidence plan. |
+| Stop conditions | Missing owner/resource; access arrangement failure; secret disclosure; production credential exposure; architecture drift; inactive required gates; ambiguity. |
+| Stage 9 exit criteria | Candidate can identify every owner, resource, workflow output, RED obligation, stop condition and required build-exit evidence artifact; no pre-appointment blocker remains. |
+
+## 7. Corrected W1 Checks
+
+| ID | Stage 9 readiness check |
+|---|---|
+| W1-01 | Candidate understands the intended ownership and purpose of `ci.yml` and `deploy-frontend.yml`, and understands `db-migrate.yml` belongs to W7. |
+| W1-02 | Candidate understands the design rule that PR/Preview work must not mutate Production or receive Production credentials/data, and accepts this as a mandatory W1 build-exit proof obligation. |
+| W1-03 | Candidate understands the root `.env.example` contract and no-committed-secret rule; the file itself is a W1 implementation output. |
+| W1-04 | Candidate identifies the required CI/type/lint/test/schema/Preview/environment evidence to be produced during W1. |
+| W1-05 | Every pre-appointment dependency and stop condition has an owner, governed arrangement and escalation path. |
+| W1-06 | Stage 9 exit criteria and later W1 build-exit criteria are separately understood and objectively verifiable. |
+
+## 8. Final Boundary
+
+This correction does not create Stage 10, appoint a builder, authorize implementation, create workflow files, run migrations, deploy Production or begin Stage 12. Stage 10 may open only after a corrected Stage 9 candidate assessment reaches PASS and CS2 explicitly authorizes progression.

--- a/modules/amc/AMC_PRE_BUILD_ARTIFACT_INDEX.md
+++ b/modules/amc/AMC_PRE_BUILD_ARTIFACT_INDEX.md
@@ -2,7 +2,7 @@
 
 **Module**: App Management Centre (AMC)  
 **Lifecycle Model**: 12-Stage Pre-Build Sequence + Stage 5a (`PRE_BUILD_STAGE_MODEL_CANON.md` v1.0.0; AMC-GOV-OVERSIGHT-001)  
-**Last Updated**: 2026-07-23 (Issue #1215 / PR #1216 corrects the W1 bootstrap-readiness model, preserves all implementation evidence obligations for W1 build exit, and records Stage 9 W1 PASS pending final CS2 review.)  
+**Last Updated**: 2026-07-23 (Issue #1215 / PR #1216 corrects the W1 bootstrap-readiness model, preserves all implementation evidence obligations for W1 build exit, and records a recommended Stage 9 W1 PASS pending final CS2 acceptance/merge.)  
 **Authority**: Maturion Foreman / CS2
 
 ---
@@ -136,9 +136,9 @@ This index catalogs all pre-build artifacts for the AMC module, mapped to their 
 | Artifact | Location | Status | Notes |
 |---|---|---|---|
 | Builder Checklist | `modules/amc/08-builder-checklist/builder-checklist.md` | ✅ Produced / Merged | PR #1204 merged the universal and W1–W8 readiness gates. |
-| W1 Bootstrap Readiness Model Correction | `modules/amc/08-builder-checklist/w1-bootstrap-readiness-model-correction-20260723.md` | ✅ Binding Correction — pending CS2 acceptance | Separates Stage 9 readiness evidence from Stage 12 W1 build-exit evidence without weakening obligations. |
+| W1 Bootstrap Readiness Model Correction | `modules/amc/08-builder-checklist/w1-bootstrap-readiness-model-correction-20260723.md` | 🟡 Proposed Correction — binding only upon CS2 acceptance/merge | Separates Stage 9 readiness evidence from Stage 12 W1 build-exit evidence without weakening obligations. |
 | Builder Readiness Attestations | `modules/amc/08-builder-checklist/builder-readiness-attestations.md` | ✅ Produced / Merged | Controlled candidate/Foreman attestation template. |
-| W1 Candidate Readiness Checklist — `integration-builder` | `modules/amc/08-builder-checklist/executions/w1/integration-builder-readiness-checklist.md` | ✅ PASS — pending CS2 acceptance | Reassessed under corrected non-circular Stage 9 model. |
+| W1 Candidate Readiness Checklist — `integration-builder` | `modules/amc/08-builder-checklist/executions/w1/integration-builder-readiness-checklist.md` | 🟡 RECOMMENDED PASS — pending CS2 acceptance/merge | Reassessed under corrected non-circular Stage 9 model. |
 | W1 Candidate Readiness Attestation v1 | `modules/amc/08-builder-checklist/executions/w1/integration-builder-readiness-attestation.md` | 📦 Historical — BLOCKED | Original PR #1206 execution retained. |
 | W1 Candidate Readiness Attestation v2 | `modules/amc/08-builder-checklist/executions/w1/integration-builder-readiness-attestation-v2-20260722.md` | ✅ Candidate Attestation Complete | Mandatory read-set and commitments recorded. |
 | W1 Environment and Dependency Register | `modules/amc/08-builder-checklist/executions/w1/w1-environment-and-dependency-register.md` | 🟡 Historical/Reconciliation Input | Resource facts retained; current readiness authority is checklist plus correction. |
@@ -151,7 +151,7 @@ This index catalogs all pre-build artifacts for the AMC module, mapped to their 
 | CS2 Decision Record — Stage 9 W1 (historical) | `modules/amc/08-builder-checklist/cs2-decision-record-stage-9-w1.md` | 📦 Historical — BLOCKED | Retained as provenance. |
 | Stage 9 W1 Bootstrap Correction Decision | `modules/amc/08-builder-checklist/cs2-decision-record-stage-9-w1-bootstrap-correction-20260723.md` | 🟡 DRAFT — recommended PASS | Final CS2 review artifact for PR #1216. |
 
-Stage 9 W1 candidate readiness is **PASS pending final CS2 acceptance of PR #1216**. This PASS is pre-appointment readiness only. W1 implementation evidence remains mandatory and unproduced.
+Stage 9 W1 candidate readiness is **RECOMMENDED PASS pending final CS2 acceptance/merge of PR #1216**. This is pre-appointment readiness only. W1 implementation evidence remains mandatory and unproduced.
 
 ---
 

--- a/modules/amc/AMC_PRE_BUILD_ARTIFACT_INDEX.md
+++ b/modules/amc/AMC_PRE_BUILD_ARTIFACT_INDEX.md
@@ -2,7 +2,7 @@
 
 **Module**: App Management Centre (AMC)  
 **Lifecycle Model**: 12-Stage Pre-Build Sequence + Stage 5a (`PRE_BUILD_STAGE_MODEL_CANON.md` v1.0.0; AMC-GOV-OVERSIGHT-001)  
-**Last Updated**: 2026-07-22 (Issue #1213 / PR #1214 records the candidate v2 re-attestation. Independent review closes the governance-reading blocker and retains governed-access, isolation, protected-production and final role-fit blockers. Stage 9 remains BLOCKED; Stages 10–12 remain blocked.)  
+**Last Updated**: 2026-07-23 (Issue #1215 / PR #1216 corrects the W1 bootstrap-readiness model, preserves all implementation evidence obligations for W1 build exit, and records Stage 9 W1 PASS pending final CS2 review.)  
 **Authority**: Maturion Foreman / CS2
 
 ---
@@ -136,21 +136,22 @@ This index catalogs all pre-build artifacts for the AMC module, mapped to their 
 | Artifact | Location | Status | Notes |
 |---|---|---|---|
 | Builder Checklist | `modules/amc/08-builder-checklist/builder-checklist.md` | ✅ Produced / Merged | PR #1204 merged the universal and W1–W8 readiness gates. |
-| Builder Readiness Attestations | `modules/amc/08-builder-checklist/builder-readiness-attestations.md` | ✅ Produced / Merged | PR #1204 merged the controlled candidate/Foreman attestation template. |
-| W1 Candidate Readiness Checklist — `integration-builder` | `modules/amc/08-builder-checklist/executions/w1/integration-builder-readiness-checklist.md` | 🔴 BLOCKED | Governance-reading blocker closed; access/isolation and final role-fit remain blocked in PR #1214. |
-| W1 Candidate Readiness Attestation v1 — `integration-builder` | `modules/amc/08-builder-checklist/executions/w1/integration-builder-readiness-attestation.md` | 📦 Historical — BLOCKED | Original PR #1206 execution retained as provenance. |
-| W1 Candidate Readiness Attestation v2 — `integration-builder` | `modules/amc/08-builder-checklist/executions/w1/integration-builder-readiness-attestation-v2-20260722.md` | 🟡 Candidate Attestation Complete | Candidate answered all statements YES and enumerated the read-set; Foreman verification does not accept unsupported access/isolation claims as PASS. |
-| W1 Environment and Dependency Register | `modules/amc/08-builder-checklist/executions/w1/w1-environment-and-dependency-register.md` | 🔴 BLOCKED | Core resources exist; candidate-specific permissions and operational isolation remain incomplete. |
-| W1 Access Boundary Evidence | `modules/amc/08-builder-checklist/executions/w1/w1-access-boundary-evidence-20260722.md` | 🟡 Partial Evidence | Boundary design documented; candidate-specific technical access and secret availability not independently demonstrated. |
-| W1 Environment Isolation Record | `modules/amc/08-builder-checklist/executions/w1/w1-environment-isolation-record-20260722.md` | 🔴 BLOCKED | Target design documented; enforceable Preview/non-production and protected-production workflow controls not yet evidenced. |
-| W1 Foreman Role-Fit Assessment | `modules/amc/08-builder-checklist/executions/w1/w1-foreman-role-fit-20260722.md` | 🔴 BLOCKED | Candidate class fit and comprehension pass; final role-fit blocked by access/isolation gaps. |
-| W1 RED-Test and Evidence Map | `modules/amc/08-builder-checklist/executions/w1/w1-red-test-and-evidence-map.md` | 🟡 Defined / BLOCKED | W1 obligations mapped; later implementation evidence remains required. |
-| W1 Environment Evidence Update | `modules/amc/08-builder-checklist/executions/w1/w1-environment-evidence-update-20260721.md` | 🟡 Partial Evidence | Records Vercel/Supabase resources and AMC secret-name presence without values. |
-| W1 Readiness Reconciliation | `modules/amc/08-builder-checklist/executions/w1/w1-readiness-reconciliation-20260722.md` | 📦 Historical — BLOCKED | Issue #1208 / merged PR #1209 reconciliation record. |
-| CS2 Decision Record — Stage 9 W1 | `modules/amc/08-builder-checklist/cs2-decision-record-stage-9-w1.md` | 🔴 Current CS2 Authority: BLOCKED | Merged PR #1209 disposition remains authoritative. |
-| Stage 9 W1 Closure Decision Draft | `modules/amc/08-builder-checklist/cs2-decision-record-stage-9-w1-closure-20260722.md` | 🔴 DRAFT / BLOCKED | No CS2 PASS issued; records current blocker assessment for review. |
+| W1 Bootstrap Readiness Model Correction | `modules/amc/08-builder-checklist/w1-bootstrap-readiness-model-correction-20260723.md` | ✅ Binding Correction — pending CS2 acceptance | Separates Stage 9 readiness evidence from Stage 12 W1 build-exit evidence without weakening obligations. |
+| Builder Readiness Attestations | `modules/amc/08-builder-checklist/builder-readiness-attestations.md` | ✅ Produced / Merged | Controlled candidate/Foreman attestation template. |
+| W1 Candidate Readiness Checklist — `integration-builder` | `modules/amc/08-builder-checklist/executions/w1/integration-builder-readiness-checklist.md` | ✅ PASS — pending CS2 acceptance | Reassessed under corrected non-circular Stage 9 model. |
+| W1 Candidate Readiness Attestation v1 | `modules/amc/08-builder-checklist/executions/w1/integration-builder-readiness-attestation.md` | 📦 Historical — BLOCKED | Original PR #1206 execution retained. |
+| W1 Candidate Readiness Attestation v2 | `modules/amc/08-builder-checklist/executions/w1/integration-builder-readiness-attestation-v2-20260722.md` | ✅ Candidate Attestation Complete | Mandatory read-set and commitments recorded. |
+| W1 Environment and Dependency Register | `modules/amc/08-builder-checklist/executions/w1/w1-environment-and-dependency-register.md` | 🟡 Historical/Reconciliation Input | Resource facts retained; current readiness authority is checklist plus correction. |
+| W1 Access Boundary Evidence | `modules/amc/08-builder-checklist/executions/w1/w1-access-boundary-evidence-20260722.md` | ✅ PASS AS READINESS ARRANGEMENT | Owners, resources, secret names/scopes and escalation path documented; actual consumption remains W1 evidence. |
+| W1 Environment Isolation Record | `modules/amc/08-builder-checklist/executions/w1/w1-environment-isolation-record-20260722.md` | ✅ PASS AS DESIGN/POLICY READINESS | Executed enforcement remains mandatory W1/W7 evidence. |
+| W1 Foreman Role-Fit Assessment | `modules/amc/08-builder-checklist/executions/w1/w1-foreman-role-fit-20260722.md` | ✅ PASS | Candidate fit confirmed under corrected Stage 9 boundary. |
+| W1 RED-Test and Evidence Map | `modules/amc/08-builder-checklist/executions/w1/w1-red-test-and-evidence-map.md` | ✅ Defined / Binding for W1 | All RED and build-exit obligations retained. |
+| W1 Environment Evidence Update | `modules/amc/08-builder-checklist/executions/w1/w1-environment-evidence-update-20260721.md` | 🟡 Resource Evidence | Vercel/Supabase resources and secret-name presence. |
+| W1 Readiness Reconciliation | `modules/amc/08-builder-checklist/executions/w1/w1-readiness-reconciliation-20260722.md` | 📦 Historical — BLOCKED | PR #1209 provenance. |
+| CS2 Decision Record — Stage 9 W1 (historical) | `modules/amc/08-builder-checklist/cs2-decision-record-stage-9-w1.md` | 📦 Historical — BLOCKED | Retained as provenance. |
+| Stage 9 W1 Bootstrap Correction Decision | `modules/amc/08-builder-checklist/cs2-decision-record-stage-9-w1-bootstrap-correction-20260723.md` | 🟡 DRAFT — recommended PASS | Final CS2 review artifact for PR #1216. |
 
-Stage 9 W1 candidate readiness remains **BLOCKED**. Passing PR #1214 ceremony gates confirms governance integrity only and does not authorize Stage 10–12.
+Stage 9 W1 candidate readiness is **PASS pending final CS2 acceptance of PR #1216**. This PASS is pre-appointment readiness only. W1 implementation evidence remains mandatory and unproduced.
 
 ---
 
@@ -158,8 +159,8 @@ Stage 9 W1 candidate readiness remains **BLOCKED**. Passing PR #1214 ceremony ga
 
 | Artifact | Location | Status | Notes |
 |---|---|---|---|
-| IAA Pre-Brief | `modules/amc/09-iaa-pre-brief/iaa-pre-brief.md` | ⬜ Placeholder — 🔴 Blocked | Not started. Blocked by Stage 9 W1 readiness. |
-| IAA Pre-Brief Response | `modules/amc/09-iaa-pre-brief/iaa-pre-brief-response.md` | ⬜ Placeholder — 🔴 Blocked | Not started. |
+| IAA Pre-Brief | `modules/amc/09-iaa-pre-brief/iaa-pre-brief.md` | ⬜ Placeholder — eligible only after CS2 acceptance and explicit authorization | Not started. |
+| IAA Pre-Brief Response | `modules/amc/09-iaa-pre-brief/iaa-pre-brief-response.md` | ⬜ Placeholder — BLOCKED | Not started. |
 
 ---
 
@@ -167,7 +168,7 @@ Stage 9 W1 candidate readiness remains **BLOCKED**. Passing PR #1214 ceremony ga
 
 | Artifact | Location | Status | Notes |
 |---|---|---|---|
-| Builder Appointment | `modules/amc/10-builder-appointment/builder-appointment.md` | ⬜ Placeholder — 🔴 Blocked | No builders appointed. |
+| Builder Appointment | `modules/amc/10-builder-appointment/builder-appointment.md` | ⬜ Placeholder — 🔴 Blocked | No builder appointed. |
 | Builder Contract | `modules/amc/10-builder-appointment/builder-contract.md` | ⬜ Placeholder — 🔴 Blocked | Not started. |
 
 ---

--- a/modules/amc/BUILD_PROGRESS_TRACKER.md
+++ b/modules/amc/BUILD_PROGRESS_TRACKER.md
@@ -2,14 +2,14 @@
 
 **Module**: App Management Centre (AMC)  
 **Module Slug**: AMC  
-**Last Updated**: 2026-07-22  
-**Updated By**: Foreman proxy — Stage 9 W1 residual blocker evidence review, issue #1213 / PR #1214
+**Last Updated**: 2026-07-23  
+**Updated By**: Foreman proxy — W1 bootstrap readiness model correction, issue #1215 / PR #1216
 
 > **Classification**: ACTIVE  
-> **Document Role**: PRIMARY LIVE CONTROL DOCUMENT — CS2 should use this document as the main live progress dashboard.  
+> **Document Role**: PRIMARY LIVE CONTROL DOCUMENT  
 > **Canon Reference**: `PRE_BUILD_STAGE_MODEL_CANON.md` v1.0.0  
-> **Current Issue**: [app_management_centre#1213](https://github.com/APGI-cmy/app_management_centre/issues/1213)  
-> **Current PR**: [app_management_centre#1214](https://github.com/APGI-cmy/app_management_centre/pull/1214)  
+> **Current Issue**: [app_management_centre#1215](https://github.com/APGI-cmy/app_management_centre/issues/1215)  
+> **Current PR**: [app_management_centre#1216](https://github.com/APGI-cmy/app_management_centre/pull/1216)  
 > **Update Rule**: Update after every AMC stage issue, wave completion, approval, or readiness/blocker change.
 
 ## Disposition History
@@ -21,78 +21,99 @@
 - PR #1194 merged Stage 7 PBFAG retrofit artifacts.
 - PR #1198 recorded CS2 approval with conditions for Stages 5, 5a, 6 and 7.
 - PR #1200 produced Stage 8 implementation-plan artifacts.
-- PR #1202 merged the CS2 Stage 8 disposition: Approved with Conditions.
+- PR #1202 merged Stage 8 Approved with Conditions.
 - PR #1204 merged the Stage 9 Builder Checklist structure.
-- PR #1206 merged the W1 candidate-readiness execution with a truthful BLOCKED result and closed Issue #1205.
-- PR #1207 was closed unmerged as a duplicate/superseded path.
-- Issue #1208 / PR #1209 reconciled the W1 record and recorded the explicit CS2 BLOCKED disposition.
-- Issue #1210 / PR #1211 was closed as a superseded duplicate path.
-- Issue #1213 / PR #1214 produced the candidate v2 re-attestation. Independent review closed the governance-reading blocker but retained access, isolation, protected-production and final role-fit blockers.
+- PR #1206 merged the original W1 BLOCKED execution.
+- PR #1209 reconciled the record and retained BLOCKED.
+- PR #1214 merged the candidate re-attestation and truthful BLOCKED residual review.
+- Issue #1215 / PR #1216 corrects the circular W1 readiness model and reassesses the candidate.
 
 ## Stage Summary
 
 | Stage | Name | Status | Notes |
 |---|---|---|---|
-| 1 | App Description | ✅ COMPLETE | Approved canonical artifact plus retrofit input. |
-| 2 | UX Workflow & Wiring Spec | ✅ COMPLETE | Approved canonical artifact plus CTA/API/Data/Audit retrofit. |
-| 3 | FRS | ✅ CS2 APPROVED | FR-1900 retrofit remains binding. |
-| 4 | TRS | ✅ TREATED AS APPROVED | TR-1900/TR-1910 remain binding; formal status note retained in artifact index. |
-| 5 | Architecture | ✅ CS2 APPROVED WITH CONDITIONS | Route/action/state/audit/degraded-mode obligations remain binding. |
-| 5a | Deployment Execution Strategy | ✅ CS2 APPROVED WITH CONDITIONS | CI, preview, environment, secret, migration, rollback and health/smoke controls remain binding. |
+| 1 | App Description | ✅ COMPLETE | Approved canonical artifact. |
+| 2 | UX Workflow & Wiring Spec | ✅ COMPLETE | Approved canonical artifact. |
+| 3 | FRS | ✅ CS2 APPROVED | FR-1900 remains binding. |
+| 4 | TRS | ✅ TREATED AS APPROVED | TR-1900/TR-1910 remain binding. |
+| 5 | Architecture | ✅ CS2 APPROVED WITH CONDITIONS | Binding downstream obligations retained. |
+| 5a | Deployment Execution Strategy | ✅ CS2 APPROVED WITH CONDITIONS | Environment/deployment controls remain binding. |
 | 6 | QA-to-Red | ✅ CS2 APPROVED WITH CONDITIONS | QA-FD and QA-DEPLOY obligations remain binding. |
-| 7 | PBFAG | ✅ CS2 APPROVED WITH CONDITIONS | PBFAG evidence rows remain binding. |
+| 7 | PBFAG | ✅ CS2 APPROVED WITH CONDITIONS | Evidence rows remain binding. |
 | 8 | Implementation Plan | ✅ CS2 APPROVED WITH CONDITIONS | Decision merged in PR #1202. |
-| 9 | Builder Checklist / W1 Readiness | 🔴 BLOCKED — residual closure reviewed | Candidate governance acknowledgement completed; operational access/isolation and final role-fit remain blocked. |
-| 10 | IAA Pre-Brief | ⬜ NOT STARTED — BLOCKED | Not authorized while Stage 9 remains BLOCKED. |
-| 11 | Builder Appointment | ⬜ NOT STARTED — BLOCKED | No builder appointed. |
-| 12 | Build | ⬜ NOT STARTED — BLOCKED | No build authorization. |
+| 9 | Builder Checklist / W1 Readiness | ✅ PASS — corrected model / final disposition pending CS2 review | Pre-appointment readiness satisfied; build-exit proof preserved for W1. |
+| 10 | IAA Pre-Brief | ⬜ NOT STARTED — ELIGIBLE PENDING EXPLICIT CS2 AUTHORIZATION | No Stage 10 artifact yet. |
+| 11 | Builder Appointment | ⬜ NOT STARTED — BLOCKED | Awaiting Stage 10 completion. |
+| 12 | Build | ⬜ NOT STARTED — BLOCKED | No implementation authority. |
 
 ## Stage 9 W1 Current Facts
 
 - Candidate: `integration-builder` — nominated only.
-- Historical attestation v1: **EXECUTED — BLOCKED**.
-- Candidate re-attestation v2: all candidate statements answered YES; mandatory read-set enumerated.
-- Candidate governance acknowledgement blocker W1-BLK-001: **CLOSED**.
-- Supabase production project: `icawesooswoqzepcdevg` — healthy.
-- Supabase non-production branch: `develop`, project ref `kkksclwvbmyexpsdyejj` — healthy.
-- Vercel project: `app-management-centre` — exists; PR Preview deployment evidence observed.
-- AMC Vercel secret names are present without values being recorded.
-- Build-to-Green phase switch is enabled.
-- `ci.yml` and `deploy-frontend.yml` are W1 implementation outputs; `db-migrate.yml` is a W7 output.
-- The current evidence does not reproducibly prove that Preview execution is technically bound to non-production Supabase credentials or excluded from production credentials.
-- The current evidence does not demonstrate an enforceable protected-production deployment path because the W1 deployment workflow does not yet exist.
+- Candidate v2 re-attestation: complete; mandatory read-set enumerated.
+- Vercel project `app-management-centre`: exists.
+- Supabase Production `icawesooswoqzepcdevg`: healthy.
+- Supabase non-production `develop` / `kkksclwvbmyexpsdyejj`: healthy.
+- AMC Vercel secret names: recorded without values.
+- Build-to-Green: enabled.
+- GitHub/Vercel/Supabase owners, intended scopes and escalation paths: documented.
+- Preview/non-production versus Production design: documented.
+- Protected-Production policy and candidate prohibitions: documented.
+- Final Foreman role-fit: PASS under corrected Stage 9 boundary.
+
+## Corrected Evidence Boundary
+
+### Stage 9 readiness evidence — complete
+
+- candidate authority and governance comprehension;
+- owners, resources and governed access arrangement;
+- secret names/scopes without values;
+- environment design and Production-protection policy;
+- stop conditions and escalation path;
+- objective W1 build-exit evidence plan.
+
+### W1 build-exit evidence — still mandatory later
+
+- `ci.yml` and `deploy-frontend.yml`;
+- `.env.example` implementation contract;
+- executed CI/type/lint/test/schema logs;
+- actual Preview-to-`develop` binding;
+- Production credential exclusion;
+- no-Production-side-effect proof;
+- deployment/isolation execution evidence;
+- W1 RED-to-GREEN evidence.
+
+`db-migrate.yml` remains a W7 output.
 
 ## Residual Blocking Items
 
-1. **W1-BLK-002:** Candidate-specific governed GitHub, Vercel and Supabase access remains incompletely demonstrated.
-2. **W1-BLK-003:** Preview/staging versus production isolation remains a target design rather than an inspected and executed control.
-3. **W1-BLK-004:** Protected-production and no-production-mutation controls remain incompletely evidenced.
-4. **W1-BLK-005:** Final Foreman role-fit cannot be approved while blockers 2–4 remain.
+No corrected Stage 9 pre-appointment blocker remains.
+
+This does not mean W1 implementation is complete. All build-exit evidence remains RED/unproduced until authorized Stage 12 work.
 
 ## Current Disposition
 
-**W1 candidate readiness: BLOCKED.**
+**W1 candidate readiness: PASS — pending explicit CS2 acceptance of PR #1216.**
 
-Passing PR ceremony gates certifies the integrity of this governance record only. It does not convert the candidate result to PASS. Stage 10, Stage 11 and Stage 12 remain prohibited until a later evidence-complete PASS and explicit CS2 authorization.
+Stage 10 may be opened only after PR #1216 receives final independent assurance, merges, and CS2 explicitly authorizes Stage 10. Stage 11 and Stage 12 remain blocked.
 
-## Current Closure Artifacts
+## Current Artifacts
 
+- `modules/amc/08-builder-checklist/w1-bootstrap-readiness-model-correction-20260723.md`
+- `modules/amc/08-builder-checklist/executions/w1/integration-builder-readiness-checklist.md`
 - `modules/amc/08-builder-checklist/executions/w1/integration-builder-readiness-attestation-v2-20260722.md`
 - `modules/amc/08-builder-checklist/executions/w1/w1-access-boundary-evidence-20260722.md`
 - `modules/amc/08-builder-checklist/executions/w1/w1-environment-isolation-record-20260722.md`
 - `modules/amc/08-builder-checklist/executions/w1/w1-foreman-role-fit-20260722.md`
-- `modules/amc/08-builder-checklist/cs2-decision-record-stage-9-w1-closure-20260722.md`
 
 ## Next Action
 
-Complete PR #1214 as a truthful BLOCKED closure record, refresh ECAP and IAA against the final substantive head, and do not open Stage 10. A later governed wave must resolve the enforceable access and isolation evidence gap without collapsing Stage 9 into unauthorized implementation.
+Complete PR #1216 review and independent assurance. If merged and accepted by CS2, open a new governed issue for Stage 10 — W1 IAA Pre-Brief.
 
 ## References
 
 - `modules/amc/07-implementation-plan/implementation-plan.md`
 - `modules/amc/07-implementation-plan/wave-breakdown.md`
 - `modules/amc/07-implementation-plan/condition-import-matrix.md`
-- `modules/amc/07-implementation-plan/cs2-decision-record-stage-8.md`
 - `modules/amc/08-builder-checklist/builder-checklist.md`
-- `modules/amc/08-builder-checklist/builder-readiness-attestations.md`
+- `modules/amc/08-builder-checklist/w1-bootstrap-readiness-model-correction-20260723.md`
 - `modules/amc/AMC_PRE_BUILD_ARTIFACT_INDEX.md`


### PR DESCRIPTION
## Summary

governing_issue: #1215
entry_condition_status: NORMAL

This PR proposes a correction to the AMC Stage 9 W1 readiness model so pre-appointment evidence is not confused with Stage 12 implementation/build-exit evidence. The correction becomes binding only when CS2 accepts and merges this PR.

## Core correction

Stage 9 may verify candidate authority, governance comprehension, named owners, existing resources, secret names/scopes, governed access arrangements, environment design, protected-production policy, stop conditions and the W1 evidence plan.

Stage 9 may not require artifacts that can only be produced after Stage 10, Stage 11 and Stage 12, including `ci.yml`, `deploy-frontend.yml`, executed CI logs, actual Preview-to-non-production binding, workflow secret-consumption proof and no-production-side-effect execution proof.

All RED and deployment obligations remain mandatory and are moved—not weakened—to the W1 build-exit evidence set. The existing root `.env.example` must be validated or updated during W1 and proved non-secret. `db-migrate.yml` remains a W7 output.

## Completed in this PR

- Record merged PR #1214 as completed.
- Propose the W1 readiness correction for CS2 acceptance on merge.
- Reassess W1-BLK-002 through W1-BLK-005.
- Update the candidate checklist, access/isolation records, Foreman role-fit, tracker and artifact index.
- Record a recommended Stage 9 PASS pending CS2 acceptance/merge.
- Refresh ECAP and independent IAA against the final substantive head.

## Boundary

This PR does not create Stage 10, appoint or delegate a builder, authorize implementation, create W1/W7 workflows, run migrations, deploy Production, create QA-to-Green evidence or begin Stage 12.

- Fixes #1215