### PR TITLE
AMC: reconcile Stage 10 post-merge progress and pre-build controls

### DIFF
--- a/.admin/pr.json
+++ b/.admin/pr.json
@@ -2,11 +2,11 @@
   "type": "governance-control",
   "requires_iaa": true,
   "requires_ecap": true,
-  "governing_issue": "#1217",
-  "scope_summary": "Prepare and disposition the canonical Stage 10 W1 IAA pre-brief, align the tracker and artifact index, and preserve the boundary that no builder appointment, delegation, implementation, migration, deployment, or Stage 12 work is authorized.",
+  "governing_issue": "#1219",
+  "scope_summary": "Reconcile the post-merge Stage 10 control surfaces with merged PR #1218, align the progress tracker, pre-build artifact index and Stage 10 pointer with the approved Stage 8 implementation plan, and preserve the boundary that Stage 11 requires separate CS2 authorization and Stage 12 remains blocked.",
   "created_by": "foreman-v2-agent",
-  "created_at": "2026-07-23T08:53:26Z",
+  "created_at": "2026-07-23T11:51:23Z",
   "execution_model": "foreman-orchestrated",
   "orchestrating_agent": "foreman-v2-agent",
-  "implementing_agent": "none-stage10-prebrief-only"
+  "implementing_agent": "none-postmerge-alignment-only"
 }

--- a/.agent-admin/assurance/iaa-wave-record-amc-w1-runtime-foundation.md
+++ b/.agent-admin/assurance/iaa-wave-record-amc-w1-runtime-foundation.md
@@ -12,6 +12,8 @@
 | Orchestrating Foreman | `foreman-v2-agent` |
 | Stage 9 authority | Merged PR #1216 / merge commit `95271c288b2ba95e3a58cb4916d6a617cef90036` |
 | Entry condition | NORMAL — Stage 9 accepted; Stage 10 explicitly authorized by CS2 |
+| Stage 10 disposition | `PREFLIGHT_BRIEF_COMPLETE` — accepted in merged PR #1218 |
+| Final assurance token | `IAA-session-1218-R2-20260723-PASS` |
 | Builder appointed | false |
 | Implementation authorized | false |
 
@@ -240,6 +242,6 @@ This disposition means the W1 assurance expectations are sufficiently defined fo
 
 ## Current Boundary
 
-- Stage 10 pre-brief: COMPLETE — pending PR review, ECAP and independent IAA confirmation.
-- Stage 11 builder appointment: BLOCKED pending Stage 10 merge and explicit CS2 authorization.
-- Stage 12 implementation: BLOCKED pending Stage 11 appointment.
+- Stage 10 pre-brief: COMPLETE — accepted through merged PR #1218 with final token `IAA-session-1218-R2-20260723-PASS`.
+- Stage 11 builder appointment: ELIGIBLE only after separate explicit CS2 authorization; no builder is appointed by this record.
+- Stage 12 implementation: BLOCKED pending a completed Stage 11 appointment and separate implementation authorization.

--- a/.agent-admin/prehandover/ecap-reconciliation-1220.md
+++ b/.agent-admin/prehandover/ecap-reconciliation-1220.md
@@ -1,0 +1,31 @@
+# ECAP Reconciliation Summary — PR #1220
+
+**Issue**: #1219  
+**PR**: #1220  
+**Branch**: `foreman/amc-stage10-postmerge-alignment`  
+**Reviewed Substantive SHA**: `3cd75b829f02dc40caf9cd5c583c5156dc8e3a68`  
+**Final IAA Token**: `IAA-session-1220-R1-20260723-PASS`
+
+protected_path_touched: true
+ecap_required: true
+ecap_invoked: true
+ecap_verdict: PASS
+ceremony_admin_appointed: true
+protected_path_ceremony_verdict: PASS
+
+## Reconciliation
+
+- Progress tracker records merged PR #1218 and completed Stage 10.
+- Pre-build artifact index records Stage 10 as accepted/current.
+- Stage 10 pointer records the accepted canonical carrier and final token.
+- W1 remains aligned with the approved Stage 8 implementation plan.
+- Stage 11 remains unstarted pending separate CS2 authorization.
+- Stage 12 remains blocked.
+
+## Boundary
+
+No builder appointment, delegation, implementation, workflow creation, migration, Production deployment, or QA-to-GREEN evidence is created.
+
+administrative_readiness: PASS
+protected_path_ceremony_verdict: PASS
+ecap_verdict: PASS

--- a/.agent-admin/prehandover/ecap-reconciliation-1220.md
+++ b/.agent-admin/prehandover/ecap-reconciliation-1220.md
@@ -3,8 +3,8 @@
 **Issue**: #1219  
 **PR**: #1220  
 **Branch**: `foreman/amc-stage10-postmerge-alignment`  
-**Reviewed Substantive SHA**: `3cd75b829f02dc40caf9cd5c583c5156dc8e3a68`  
-**Final IAA Token**: `IAA-session-1220-R1-20260723-PASS`
+**Reviewed Substantive SHA**: `32e00be883df962eb602fadecaab336a093d897a`  
+**Final IAA Token**: `IAA-session-1220-R2-20260723-PASS`
 
 protected_path_touched: true
 ecap_required: true
@@ -15,10 +15,14 @@ protected_path_ceremony_verdict: PASS
 
 ## Reconciliation
 
-- Progress tracker records merged PR #1218 and completed Stage 10.
+- Progress tracker records merged PR #1218, completed Stage 10, active Issue #1219 and PR #1220.
 - Pre-build artifact index records Stage 10 as accepted/current.
 - Stage 10 pointer records the accepted canonical carrier and final token.
+- Canonical Stage 10 carrier is normalized to the accepted post-merge state.
 - W1 remains aligned with the approved Stage 8 implementation plan.
+- `ci.yml` is introduced in W1 and remains a W8 consolidation/validation surface.
+- `deploy-frontend.yml` is introduced in W1 and remains a W7 deployment-execution validation surface.
+- `db-migrate.yml` remains a W7 output.
 - Stage 11 remains unstarted pending separate CS2 authorization.
 - Stage 12 remains blocked.
 

--- a/.agent-admin/wave-records/amc-wave-record-stage10-postmerge-alignment-1220.md
+++ b/.agent-admin/wave-records/amc-wave-record-stage10-postmerge-alignment-1220.md
@@ -1,0 +1,37 @@
+# AMC Wave Record — Stage 10 Post-Merge Alignment
+
+Issue: #1219
+PR: #1220
+Branch: `foreman/amc-stage10-postmerge-alignment`
+Reviewed SHA: 3cd75b829f02dc40caf9cd5c583c5156dc8e3a68
+Verdict: PASS
+Adoption Phase: PHASE_B_BLOCKING
+PHASE_B_BLOCKING_TOKEN: IAA-session-1220-R1-20260723-PASS
+
+## Scope
+
+Reconcile the progress tracker, pre-build artifact index and Stage 10 pointer after merged PR #1218. Confirm alignment with the approved Stage 8 implementation plan without appointing a builder or authorizing Stage 12.
+
+## Findings
+
+- Stage 10 is correctly recorded as `PREFLIGHT_BRIEF_COMPLETE`.
+- Stage 11 is the next eligible stage and requires separate CS2 authorization.
+- Stage 12 remains blocked.
+- W1 remains the next delivery wave.
+- W1 retains CI, Preview, environment, secret-boundary and no-Production-side-effect obligations.
+- `ci.yml` and `deploy-frontend.yml` remain W1 implementation outputs.
+- `db-migrate.yml` remains a W7 output.
+- No wave was skipped, reordered or weakened.
+
+protected_path_touched: true
+ecap_required: true
+ecap_invoked: true
+ecap_verdict: PASS
+ceremony_admin_appointed: true
+protected_path_ceremony_verdict: PASS
+
+delta_assurance_verdict: PASS
+delta_classification: token-recording-only
+base_head: 3cd75b829f02dc40caf9cd5c583c5156dc8e3a68
+final_head: 3cd75b829f02dc40caf9cd5c583c5156dc8e3a68
+final_token_binding: IAA-session-1220-R1-20260723-PASS

--- a/.agent-admin/wave-records/amc-wave-record-stage10-postmerge-alignment-1220.md
+++ b/.agent-admin/wave-records/amc-wave-record-stage10-postmerge-alignment-1220.md
@@ -3,23 +3,25 @@
 Issue: #1219
 PR: #1220
 Branch: `foreman/amc-stage10-postmerge-alignment`
-Reviewed SHA: 3cd75b829f02dc40caf9cd5c583c5156dc8e3a68
+Reviewed SHA: 32e00be883df962eb602fadecaab336a093d897a
 Verdict: PASS
 Adoption Phase: PHASE_B_BLOCKING
-PHASE_B_BLOCKING_TOKEN: IAA-session-1220-R1-20260723-PASS
+PHASE_B_BLOCKING_TOKEN: IAA-session-1220-R2-20260723-PASS
 
 ## Scope
 
-Reconcile the progress tracker, pre-build artifact index and Stage 10 pointer after merged PR #1218. Confirm alignment with the approved Stage 8 implementation plan without appointing a builder or authorizing Stage 12.
+Reconcile the progress tracker, pre-build artifact index, canonical Stage 10 carrier and Stage 10 pointer after merged PR #1218. Confirm alignment with the approved Stage 8 implementation plan without appointing a builder or authorizing Stage 12.
 
 ## Findings
 
-- Stage 10 is correctly recorded as `PREFLIGHT_BRIEF_COMPLETE`.
+- Stage 10 is correctly recorded as `PREFLIGHT_BRIEF_COMPLETE` and accepted through merged PR #1218.
+- The canonical Stage 10 carrier no longer retains pre-merge or pending-assurance wording.
 - Stage 11 is the next eligible stage and requires separate CS2 authorization.
 - Stage 12 remains blocked.
 - W1 remains the next delivery wave.
 - W1 retains CI, Preview, environment, secret-boundary and no-Production-side-effect obligations.
-- `ci.yml` and `deploy-frontend.yml` remain W1 implementation outputs.
+- `ci.yml` is introduced in W1 and remains a W8 consolidation/validation surface.
+- `deploy-frontend.yml` is introduced in W1 and remains a W7 deployment-execution validation surface.
 - `db-migrate.yml` remains a W7 output.
 - No wave was skipped, reordered or weakened.
 
@@ -32,6 +34,6 @@ protected_path_ceremony_verdict: PASS
 
 delta_assurance_verdict: PASS
 delta_classification: token-recording-only
-base_head: 3cd75b829f02dc40caf9cd5c583c5156dc8e3a68
-final_head: 3cd75b829f02dc40caf9cd5c583c5156dc8e3a68
-final_token_binding: IAA-session-1220-R1-20260723-PASS
+base_head: 32e00be883df962eb602fadecaab336a093d897a
+final_head: 32e00be883df962eb602fadecaab336a093d897a
+final_token_binding: IAA-session-1220-R2-20260723-PASS

--- a/.agent-workspace/independent-assurance-agent/memory/session-1220-20260723.md
+++ b/.agent-workspace/independent-assurance-agent/memory/session-1220-20260723.md
@@ -1,0 +1,35 @@
+# IAA Session — PR #1220 — AMC Stage 10 Post-Merge Alignment
+
+Issue: #1219
+PR: #1220
+governing_issue: #1219
+Branch: foreman/amc-stage10-postmerge-alignment
+Reviewed SHA: 3cd75b829f02dc40caf9cd5c583c5156dc8e3a68
+Verdict: PASS
+Adoption Phase: PHASE_B_BLOCKING
+PHASE_B_BLOCKING_TOKEN: IAA-session-1220-R1-20260723-PASS
+
+## Assurance Scope
+
+Independent assurance reviewed the post-merge reconciliation of the AMC progress tracker, pre-build artifact index and Stage 10 pointer against merged PR #1218 and the approved Stage 8 implementation plan.
+
+## Findings
+
+1. Stage 10 completion is accurately recorded.
+2. Stage 11 remains unstarted and requires separate explicit CS2 authorization.
+3. Stage 12 remains blocked.
+4. W1 remains the next delivery wave.
+5. W1 CI, Preview isolation, environment separation, secret-boundary and no-Production-side-effect obligations are preserved.
+6. `ci.yml` and `deploy-frontend.yml` remain W1 implementation outputs.
+7. `db-migrate.yml` remains a W7 output.
+8. No builder appointment, delegation or implementation authority is created.
+
+## Assurance Verdict
+
+PASS — the pre-build control surfaces accurately reflect real current progress and remain aligned with the approved implementation plan.
+
+delta_assurance_verdict: PASS
+delta_classification: token-recording-only
+base_head: 3cd75b829f02dc40caf9cd5c583c5156dc8e3a68
+final_head: 3cd75b829f02dc40caf9cd5c583c5156dc8e3a68
+final_token_binding: IAA-session-1220-R1-20260723-PASS

--- a/.agent-workspace/independent-assurance-agent/memory/session-1220-20260723.md
+++ b/.agent-workspace/independent-assurance-agent/memory/session-1220-20260723.md
@@ -4,25 +4,27 @@ Issue: #1219
 PR: #1220
 governing_issue: #1219
 Branch: foreman/amc-stage10-postmerge-alignment
-Reviewed SHA: 3cd75b829f02dc40caf9cd5c583c5156dc8e3a68
+Reviewed SHA: 32e00be883df962eb602fadecaab336a093d897a
 Verdict: PASS
 Adoption Phase: PHASE_B_BLOCKING
-PHASE_B_BLOCKING_TOKEN: IAA-session-1220-R1-20260723-PASS
+PHASE_B_BLOCKING_TOKEN: IAA-session-1220-R2-20260723-PASS
 
 ## Assurance Scope
 
-Independent assurance reviewed the post-merge reconciliation of the AMC progress tracker, pre-build artifact index and Stage 10 pointer against merged PR #1218 and the approved Stage 8 implementation plan.
+Independent assurance reviewed the post-merge reconciliation of the AMC progress tracker, pre-build artifact index, canonical Stage 10 carrier and Stage 10 pointer against merged PR #1218 and the approved Stage 8 implementation plan.
 
 ## Findings
 
-1. Stage 10 completion is accurately recorded.
+1. Stage 10 completion is accurately recorded and the canonical carrier is normalized to the accepted post-merge state.
 2. Stage 11 remains unstarted and requires separate explicit CS2 authorization.
 3. Stage 12 remains blocked.
 4. W1 remains the next delivery wave.
 5. W1 CI, Preview isolation, environment separation, secret-boundary and no-Production-side-effect obligations are preserved.
-6. `ci.yml` and `deploy-frontend.yml` remain W1 implementation outputs.
-7. `db-migrate.yml` remains a W7 output.
-8. No builder appointment, delegation or implementation authority is created.
+6. `ci.yml` is introduced in W1 and remains a W8 consolidation/validation surface.
+7. `deploy-frontend.yml` is introduced in W1 and remains a W7 deployment-execution validation surface.
+8. `db-migrate.yml` remains a W7 output.
+9. No builder appointment, delegation or implementation authority is created.
+10. Tracker, index, pointer, canonical carrier and PR metadata agree on the current state.
 
 ## Assurance Verdict
 
@@ -30,6 +32,6 @@ PASS — the pre-build control surfaces accurately reflect real current progress
 
 delta_assurance_verdict: PASS
 delta_classification: token-recording-only
-base_head: 3cd75b829f02dc40caf9cd5c583c5156dc8e3a68
-final_head: 3cd75b829f02dc40caf9cd5c583c5156dc8e3a68
-final_token_binding: IAA-session-1220-R1-20260723-PASS
+base_head: 32e00be883df962eb602fadecaab336a093d897a
+final_head: 32e00be883df962eb602fadecaab336a093d897a
+final_token_binding: IAA-session-1220-R2-20260723-PASS

--- a/modules/amc/09-iaa-pre-brief/iaa-pre-brief.md
+++ b/modules/amc/09-iaa-pre-brief/iaa-pre-brief.md
@@ -2,9 +2,9 @@
 
 **Stage**: 10 — IAA Pre-Brief  
 **Module**: App Management Centre (AMC)  
-**Status**: 🟡 Active — `PREFLIGHT_BRIEF_COMPLETE` pending merge/CS2 acceptance of PR #1218  
-**Governing issue / PR**: #1217 / #1218  
-**Prerequisite**: Stage 9 Builder Checklist complete and accepted in merged PR #1216
+**Status**: ✅ COMPLETE — `PREFLIGHT_BRIEF_COMPLETE`  
+**Disposition Source**: Issue #1217 / merged PR #1218  
+**Final Assurance Token**: `IAA-session-1218-R2-20260723-PASS`
 
 ---
 
@@ -12,74 +12,57 @@
 
 Stage 10 defines the independent assurance pre-brief required before AMC builder appointment.
 
-Under the AMC PR #1800 alignment model, the active IAA pre-brief is not a standalone `iaa-prebrief-*` file. It is recorded in the canonical wave record using:
+The W1 Stage 10 pre-brief is complete and accepted through merged PR #1218. This file is a pointer and status surface only; it is not the authoritative pre-brief body.
+
+## Canonical active carrier
+
+```text
+.agent-admin/assurance/iaa-wave-record-amc-w1-runtime-foundation.md
+```
+
+The canonical carrier contains:
 
 ```text
 ## PRE-BRIEF
 IAA_PREFLIGHT_BRIEF
 ```
 
-Canonical active carrier for W1:
+and the schema-conformant preflight payload required by:
 
 ```text
-.agent-admin/assurance/iaa-wave-record-amc-w1-runtime-foundation.md
+.agent-admin/control/schemas/iaa-preflight-brief.schema.json
 ```
 
----
-
-## Active protocol
-
-Active protocol references:
+## Binding protocol
 
 ```text
 governance/canon/IAA_PRE_BRIEF_PROTOCOL.md
 .agent-admin/control/protocols/IAA_PREFLIGHT_BRIEF_PROTOCOL.md
-.agent-admin/control/schemas/iaa-preflight-brief.schema.json
 .github/agents/independent-assurance-agent.md
 ```
 
-Legacy standalone `.agent-admin/assurance/iaa-prebrief-*` artifacts are retained only as historical/provenance records.
+Legacy standalone `.agent-admin/assurance/iaa-prebrief-*` artifacts remain historical/provenance records only.
 
----
+## Completed Stage 10 scope
 
-## Stage 10 entry conditions
+The accepted W1 pre-brief defines:
 
-The W1 Stage 10 entry conditions are satisfied:
-
-1. Stage 8 Implementation Plan exists and is approved with conditions;
-2. Stage 9 Builder Checklist exists and W1 readiness PASS was accepted in merged PR #1216;
-3. the W1 scope is known;
-4. the expected QA-to-Red scope is current;
-5. CS2 explicitly authorized Stage 10 in issue #1217.
-
----
-
-## Required pre-brief contents
-
-The canonical W1 wave-record pre-brief includes:
-
-- wave/job identifier;
-- issue and PR reference;
-- branch and authority context;
-- schema-conformant `IAA_PREFLIGHT_BRIEF` JSON payload;
+- wave/job identity and authority;
+- exact W1 scope and exclusions;
 - qualifying tasks;
-- expected QA scope;
+- expected QA and RED scope;
 - high-risk failure modes;
-- required builder evidence;
-- required Foreman QP checks;
-- ECAP requirement status;
+- required builder outputs and evidence;
+- required Foreman quality-control checks;
+- ECAP applicability;
 - final IAA focus;
 - stop and escalation conditions;
 - disposition `PREFLIGHT_BRIEF_COMPLETE`.
 
----
+## Current boundary
 
-## Current disposition
+- Stage 10: COMPLETE.
+- Stage 11: eligible only after separate explicit CS2 authorization; no builder appointed yet.
+- Stage 12: BLOCKED; no implementation authority.
 
-```text
-PREFLIGHT_BRIEF_COMPLETE
-```
-
-This means the W1 assurance expectations are sufficiently defined for Stage 11 consideration after PR #1218 merges and CS2 accepts Stage 10.
-
-It does not appoint or delegate `integration-builder`, authorize Stage 12, create implementation outputs, run migrations, or deploy Production.
+Completion of Stage 10 does not create a builder appointment, delegation order, workflow implementation, migration authority, Production deployment authority, or W1 QA-to-GREEN evidence.

--- a/modules/amc/AMC_PRE_BUILD_ARTIFACT_INDEX.md
+++ b/modules/amc/AMC_PRE_BUILD_ARTIFACT_INDEX.md
@@ -2,7 +2,7 @@
 
 **Module**: App Management Centre (AMC)  
 **Lifecycle Model**: 12-Stage Pre-Build Sequence + Stage 5a (`PRE_BUILD_STAGE_MODEL_CANON.md` v1.0.0; AMC-GOV-OVERSIGHT-001)  
-**Last Updated**: 2026-07-23 (Merged PR #1218 completed the W1 Stage 10 IAA Pre-Brief. Issue #1219 reconciles post-merge control metadata and confirms Stage 11 as the next eligible, separately authorized stage.)  
+**Last Updated**: 2026-07-23 (Merged PR #1218 completed the W1 Stage 10 IAA Pre-Brief. Issue #1219 / PR #1220 reconciles post-merge control metadata and confirms Stage 11 as the next eligible, separately authorized stage.)  
 **Authority**: Maturion Foreman / CS2
 
 ---
@@ -194,7 +194,8 @@ The pre-build pack remains aligned with the approved Stage 8 plan:
 - W1 remains the next delivery wave.
 - W1 retains CI, Preview, environment and secret-boundary controls.
 - W1 retains CI, Preview-isolation, environment-separation, secret-boundary and no-Production-side-effect RED coverage.
-- `ci.yml` and `deploy-frontend.yml` remain W1 implementation outputs.
+- `ci.yml` is introduced in W1 and remains a W8 consolidation/validation surface.
+- `deploy-frontend.yml` is introduced in W1 and remains a W7 deployment-execution validation surface.
 - `db-migrate.yml` remains a W7 output.
 - W1 and W2 must complete before material user-action work.
 - No delivery wave has been skipped, reordered or weakened.

--- a/modules/amc/AMC_PRE_BUILD_ARTIFACT_INDEX.md
+++ b/modules/amc/AMC_PRE_BUILD_ARTIFACT_INDEX.md
@@ -2,7 +2,7 @@
 
 **Module**: App Management Centre (AMC)  
 **Lifecycle Model**: 12-Stage Pre-Build Sequence + Stage 5a (`PRE_BUILD_STAGE_MODEL_CANON.md` v1.0.0; AMC-GOV-OVERSIGHT-001)  
-**Last Updated**: 2026-07-23 (Issue #1217 / PR #1218 records the active W1 Stage 10 IAA Pre-Brief and preserves the Stage 11/12 boundary.)  
+**Last Updated**: 2026-07-23 (Merged PR #1218 completed the W1 Stage 10 IAA Pre-Brief. Issue #1219 reconciles post-merge control metadata and confirms Stage 11 as the next eligible, separately authorized stage.)  
 **Authority**: Maturion Foreman / CS2
 
 ---
@@ -158,13 +158,13 @@ Stage 9 W1 candidate readiness is **PASS ACCEPTED**. This is pre-appointment rea
 
 | Artifact | Location | Status | Notes |
 |---|---|---|---|
-| Stage 10 Pointer | `modules/amc/09-iaa-pre-brief/iaa-pre-brief.md` | 🟡 ACTIVE | Points to the canonical W1 wave-record carrier. |
-| Canonical W1 IAA Pre-Brief | `.agent-admin/assurance/iaa-wave-record-amc-w1-runtime-foundation.md` | 🟡 PREFLIGHT_BRIEF_COMPLETE — pending merge/CS2 acceptance | Contains schema-conformant payload and full assurance plan. |
-| PR-Specific Stage 10 Wave Record | `.agent-admin/wave-records/amc-wave-record-stage10-w1-iaa-prebrief-1218.md` | ✅ Assurance Carrier | Carries PR #1218 ECAP/IAA token and Stage 10 disposition. |
-| Stage 10 IAA Memory | `.agent-workspace/independent-assurance-agent/memory/session-1218-20260723.md` | ✅ PASS | Independent assurance record for PR #1218. |
-| Stage 10 ECAP Reconciliation | `.agent-admin/prehandover/ecap-reconciliation-1218.md` | ✅ PASS | Protected-path ceremony record. |
+| Stage 10 Pointer | `modules/amc/09-iaa-pre-brief/iaa-pre-brief.md` | ✅ COMPLETE POINTER | Points to the accepted canonical W1 carrier and final assurance token. |
+| Canonical W1 IAA Pre-Brief | `.agent-admin/assurance/iaa-wave-record-amc-w1-runtime-foundation.md` | ✅ `PREFLIGHT_BRIEF_COMPLETE` | Accepted through merged PR #1218; schema-conformant payload and full assurance plan. |
+| PR-Specific Stage 10 Wave Record | `.agent-admin/wave-records/amc-wave-record-stage10-w1-iaa-prebrief-1218.md` | ✅ Current Assurance Carrier | Carries PR #1218 ECAP/IAA token and Stage 10 disposition. |
+| Stage 10 IAA Memory | `.agent-workspace/independent-assurance-agent/memory/session-1218-20260723.md` | ✅ PASS | Final assurance token `IAA-session-1218-R2-20260723-PASS`. |
+| Stage 10 ECAP Reconciliation | `.agent-admin/prehandover/ecap-reconciliation-1218.md` | ✅ PASS | Protected-path ceremony record for merged PR #1218. |
 
-Stage 10 is complete at pre-brief level, pending merge and CS2 acceptance of PR #1218. No builder is appointed and no implementation is authorized.
+Stage 10 is **COMPLETE**. The W1 pre-brief is accepted and suitable for Stage 11 consideration. No builder is appointed and no implementation is authorized.
 
 ---
 
@@ -172,8 +172,8 @@ Stage 10 is complete at pre-brief level, pending merge and CS2 acceptance of PR 
 
 | Artifact | Location | Status | Notes |
 |---|---|---|---|
-| Builder Appointment | `modules/amc/10-builder-appointment/builder-appointment.md` | ⬜ Placeholder — 🔴 Blocked | Requires Stage 10 merge and separate CS2 authorization. |
-| Builder Contract | `modules/amc/10-builder-appointment/builder-contract.md` | ⬜ Placeholder — 🔴 Blocked | Not started. |
+| Builder Appointment | `modules/amc/10-builder-appointment/builder-appointment.md` | ⬜ Placeholder — 🟡 Eligible pending explicit CS2 authorization | `integration-builder` remains nominated/readiness-approved but not appointed. |
+| Builder Contract | `modules/amc/10-builder-appointment/builder-contract.md` | ⬜ Placeholder — 🟡 Eligible pending explicit CS2 authorization | Must preserve Stage 8 W1 scope and Stage 10 assurance conditions. |
 
 ---
 
@@ -181,9 +181,23 @@ Stage 10 is complete at pre-brief level, pending merge and CS2 acceptance of PR 
 
 | Artifact | Location | Status | Notes |
 |---|---|---|---|
-| Build Evidence Index | `modules/amc/11-build/build-evidence-index.md` | ⬜ Placeholder — 🔴 Blocked | Not started. |
+| Build Evidence Index | `modules/amc/11-build/build-evidence-index.md` | ⬜ Placeholder — 🔴 Blocked | Requires completed Stage 11 appointment and separate Stage 12 authority. |
 | QA-to-Green Evidence | `modules/amc/11-build/qa-to-green-evidence.md` | ⬜ Placeholder — 🔴 Blocked | Not started. |
 | Handover | `modules/amc/11-build/handover.md` | ⬜ Placeholder — 🔴 Blocked | Not started. |
+
+---
+
+## Implementation Plan Alignment
+
+The pre-build pack remains aligned with the approved Stage 8 plan:
+
+- W1 remains the next delivery wave.
+- W1 retains CI, Preview, environment and secret-boundary controls.
+- W1 retains CI, Preview-isolation, environment-separation, secret-boundary and no-Production-side-effect RED coverage.
+- `ci.yml` and `deploy-frontend.yml` remain W1 implementation outputs.
+- `db-migrate.yml` remains a W7 output.
+- W1 and W2 must complete before material user-action work.
+- No delivery wave has been skipped, reordered or weakened.
 
 ---
 

--- a/modules/amc/BUILD_PROGRESS_TRACKER.md
+++ b/modules/amc/BUILD_PROGRESS_TRACKER.md
@@ -3,13 +3,13 @@
 **Module**: App Management Centre (AMC)  
 **Module Slug**: AMC  
 **Last Updated**: 2026-07-23  
-**Updated By**: Foreman proxy — Stage 10 post-merge alignment, issue #1219
+**Updated By**: Foreman proxy — Stage 10 post-merge alignment, issue #1219 / PR #1220
 
 > **Classification**: ACTIVE  
 > **Document Role**: PRIMARY LIVE CONTROL DOCUMENT  
 > **Canon Reference**: `PRE_BUILD_STAGE_MODEL_CANON.md` v1.0.0  
 > **Current Issue**: [app_management_centre#1219](https://github.com/APGI-cmy/app_management_centre/issues/1219)  
-> **Current PR**: Post-merge alignment PR to be opened from `foreman/amc-stage10-postmerge-alignment`  
+> **Current PR**: [app_management_centre#1220](https://github.com/APGI-cmy/app_management_centre/pull/1220)  
 > **Update Rule**: Update after every AMC stage issue, wave completion, approval, or readiness/blocker change.
 
 ## Disposition History
@@ -28,7 +28,7 @@
 - PR #1214 merged the candidate re-attestation and truthful BLOCKED residual review.
 - PR #1216 merged the corrected W1 readiness model and accepted the Stage 9 W1 PASS.
 - PR #1218 merged the canonical Stage 10 W1 IAA Pre-Brief with disposition `PREFLIGHT_BRIEF_COMPLETE` at merge commit `7889309cf4f357894d496bde1bf79349a24bb450`.
-- Issue #1219 reconciles post-merge tracker/index/pointer status only.
+- Issue #1219 / PR #1220 reconciles post-merge tracker/index/pointer status only.
 
 ## Stage Summary
 
@@ -99,16 +99,16 @@ The current posture remains aligned with the approved Stage 8 implementation pla
 - W1 scope remains Runtime Foundation and Environment Setup.
 - Required controls remain CI, Preview, secret and environment boundaries.
 - Required W1 RED coverage remains CI, Preview isolation, environment separation, secret boundaries and no-Production-side-effect tests.
-- `.github/workflows/ci.yml` is a W1 implementation output.
-- `.github/workflows/deploy-frontend.yml` is a W1 implementation output.
+- `.github/workflows/ci.yml` is introduced in W1 and remains a W8 consolidation/validation surface.
+- `.github/workflows/deploy-frontend.yml` is introduced in W1 and remains a W7 deployment-execution validation surface.
 - `db-migrate.yml` remains a W7 output.
 - W1 and W2 must complete before material user-action work.
 - No later wave is opened or reordered by the Stage 10 completion.
 
 ## W1 Build-Exit Evidence — Still Mandatory Later
 
-- `.github/workflows/ci.yml`;
-- `.github/workflows/deploy-frontend.yml`;
+- `.github/workflows/ci.yml` creation and W1 proof, with W8 consolidation still required;
+- `.github/workflows/deploy-frontend.yml` creation and W1 proof, with W7 deployment validation still required;
 - validation/update of the existing root `.env.example` without secrets;
 - executed CI/type/lint/test/schema logs;
 - actual Preview-to-`develop` binding;
@@ -140,7 +140,7 @@ Stage 11 is now the next eligible governed stage but is not yet authorized. Stag
 
 ## Next Action
 
-Complete and merge the narrow Issue #1219 post-merge alignment PR. After that, CS2 may explicitly authorize **Stage 11 — W1 Builder Appointment**. Do not begin Stage 12 implementation before Stage 11 is completed and separately accepted.
+Complete and merge Issue #1219 / PR #1220. After that, CS2 may explicitly authorize **Stage 11 — W1 Builder Appointment**. Do not begin Stage 12 implementation before Stage 11 is completed and separately accepted.
 
 ## References
 

--- a/modules/amc/BUILD_PROGRESS_TRACKER.md
+++ b/modules/amc/BUILD_PROGRESS_TRACKER.md
@@ -3,13 +3,13 @@
 **Module**: App Management Centre (AMC)  
 **Module Slug**: AMC  
 **Last Updated**: 2026-07-23  
-**Updated By**: Foreman proxy — Stage 10 W1 IAA Pre-Brief, issue #1217 / PR #1218
+**Updated By**: Foreman proxy — Stage 10 post-merge alignment, issue #1219
 
 > **Classification**: ACTIVE  
 > **Document Role**: PRIMARY LIVE CONTROL DOCUMENT  
 > **Canon Reference**: `PRE_BUILD_STAGE_MODEL_CANON.md` v1.0.0  
-> **Current Issue**: [app_management_centre#1217](https://github.com/APGI-cmy/app_management_centre/issues/1217)  
-> **Current PR**: [app_management_centre#1218](https://github.com/APGI-cmy/app_management_centre/pull/1218)  
+> **Current Issue**: [app_management_centre#1219](https://github.com/APGI-cmy/app_management_centre/issues/1219)  
+> **Current PR**: Post-merge alignment PR to be opened from `foreman/amc-stage10-postmerge-alignment`  
 > **Update Rule**: Update after every AMC stage issue, wave completion, approval, or readiness/blocker change.
 
 ## Disposition History
@@ -27,7 +27,8 @@
 - PR #1209 reconciled the record and retained BLOCKED.
 - PR #1214 merged the candidate re-attestation and truthful BLOCKED residual review.
 - PR #1216 merged the corrected W1 readiness model and accepted the Stage 9 W1 PASS.
-- Issue #1217 / PR #1218 prepares and dispositions the canonical Stage 10 W1 IAA Pre-Brief.
+- PR #1218 merged the canonical Stage 10 W1 IAA Pre-Brief with disposition `PREFLIGHT_BRIEF_COMPLETE` at merge commit `7889309cf4f357894d496bde1bf79349a24bb450`.
+- Issue #1219 reconciles post-merge tracker/index/pointer status only.
 
 ## Stage Summary
 
@@ -43,9 +44,9 @@
 | 7 | PBFAG | ✅ CS2 APPROVED WITH CONDITIONS | Evidence rows remain binding. |
 | 8 | Implementation Plan | ✅ CS2 APPROVED WITH CONDITIONS | Decision merged in PR #1202. |
 | 9 | Builder Checklist / W1 Readiness | ✅ COMPLETE — PASS ACCEPTED | Corrected pre-appointment readiness model accepted in merged PR #1216. |
-| 10 | IAA Pre-Brief | 🟡 ACTIVE — PREFLIGHT_BRIEF_COMPLETE pending merge/CS2 acceptance | Canonical W1 pre-brief is in PR #1218. |
-| 11 | Builder Appointment | ⬜ NOT STARTED — BLOCKED | Awaiting Stage 10 merge and separate CS2 authorization. |
-| 12 | Build | ⬜ NOT STARTED — BLOCKED | No implementation authority. |
+| 10 | IAA Pre-Brief | ✅ COMPLETE — `PREFLIGHT_BRIEF_COMPLETE` | Accepted through merged PR #1218; final token `IAA-session-1218-R2-20260723-PASS`. |
+| 11 | Builder Appointment | ⬜ NOT STARTED — ELIGIBLE PENDING EXPLICIT CS2 AUTHORIZATION | `integration-builder` remains nominated/readiness-approved but not appointed. |
+| 12 | Build | ⬜ NOT STARTED — BLOCKED | No implementation authority; requires completed Stage 11 appointment. |
 
 ## Stage 9 W1 Final Facts
 
@@ -67,13 +68,19 @@ Canonical carrier:
 .agent-admin/assurance/iaa-wave-record-amc-w1-runtime-foundation.md
 ```
 
-Current disposition:
+Final disposition:
 
 ```text
 PREFLIGHT_BRIEF_COMPLETE
 ```
 
-The pre-brief defines:
+Final assurance token:
+
+```text
+IAA-session-1218-R2-20260723-PASS
+```
+
+The accepted pre-brief defines:
 
 - exact W1 scope and exclusions;
 - applicable QA-to-Red and deployment obligations;
@@ -83,6 +90,20 @@ The pre-brief defines:
 - ECAP applicability;
 - final IAA focus;
 - stop and escalation conditions.
+
+## Implementation Plan Alignment
+
+The current posture remains aligned with the approved Stage 8 implementation plan and wave breakdown:
+
+- W1 is the next delivery wave.
+- W1 scope remains Runtime Foundation and Environment Setup.
+- Required controls remain CI, Preview, secret and environment boundaries.
+- Required W1 RED coverage remains CI, Preview isolation, environment separation, secret boundaries and no-Production-side-effect tests.
+- `.github/workflows/ci.yml` is a W1 implementation output.
+- `.github/workflows/deploy-frontend.yml` is a W1 implementation output.
+- `db-migrate.yml` remains a W7 output.
+- W1 and W2 must complete before material user-action work.
+- No later wave is opened or reordered by the Stage 10 completion.
 
 ## W1 Build-Exit Evidence — Still Mandatory Later
 
@@ -100,12 +121,17 @@ The pre-brief defines:
 
 ## Current Disposition
 
-**Stage 10 W1 IAA Pre-Brief: PREFLIGHT_BRIEF_COMPLETE — pending merge and final CS2 acceptance of PR #1218.**
+**Stages 1–10 are complete for W1 pre-build progression.**
 
-This does not appoint the builder or authorize Stage 12. Stage 11 requires a separate CS2-authorized appointment issue after Stage 10 is accepted.
+Stage 11 is now the next eligible governed stage but is not yet authorized. Stage 12 remains blocked. No builder is appointed and no implementation work has begun.
 
 ## Current Artifacts
 
+- `modules/amc/07-implementation-plan/implementation-plan.md`
+- `modules/amc/07-implementation-plan/wave-breakdown.md`
+- `modules/amc/07-implementation-plan/condition-import-matrix.md`
+- `modules/amc/08-builder-checklist/w1-bootstrap-readiness-model-correction-20260723.md`
+- `modules/amc/08-builder-checklist/executions/w1/integration-builder-readiness-checklist.md`
 - `.agent-admin/assurance/iaa-wave-record-amc-w1-runtime-foundation.md`
 - `.agent-admin/wave-records/amc-wave-record-stage10-w1-iaa-prebrief-1218.md`
 - `.agent-admin/prehandover/ecap-reconciliation-1218.md`
@@ -114,7 +140,7 @@ This does not appoint the builder or authorize Stage 12. Stage 11 requires a sep
 
 ## Next Action
 
-Complete review and merge of PR #1218. After merge, CS2 may separately authorize Stage 11 — W1 Builder Appointment. Do not begin Stage 12 implementation before Stage 11 is completed.
+Complete and merge the narrow Issue #1219 post-merge alignment PR. After that, CS2 may explicitly authorize **Stage 11 — W1 Builder Appointment**. Do not begin Stage 12 implementation before Stage 11 is completed and separately accepted.
 
 ## References
 


### PR DESCRIPTION
## Summary

governing_issue: #1219
entry_condition_status: NORMAL

This PR reconciles the AMC live control surfaces after merged PR #1218.

It records Stage 10 as complete with disposition `PREFLIGHT_BRIEF_COMPLETE`, aligns the tracker and artifact index with the approved Stage 8 implementation plan, and identifies Stage 11 as the next eligible stage requiring separate CS2 authorization.

## Scope

- Record PR #1218 as merged and Issue #1217 as completed.
- Mark Stage 10 COMPLETE.
- Update the Stage 10 pointer to the accepted canonical carrier.
- Confirm W1 remains the next delivery wave.
- Preserve W1 CI, Preview, environment, secret-boundary and no-Production-side-effect obligations.
- Preserve `db-migrate.yml` as W7 scope.
- Keep Stage 11 unstarted pending explicit CS2 authorization.
- Keep Stage 12 blocked.

## Boundary

This PR does not appoint a builder, issue a delegation order, authorize implementation, create workflow files, run migrations, deploy Production, or create W1 QA-to-GREEN evidence.

- Fixes #1219