### PR TITLE
AMC: appoint integration-builder for W1

### DIFF
--- a/.admin/pr.json
+++ b/.admin/pr.json
@@ -2,11 +2,11 @@
   "type": "governance-control",
   "requires_iaa": true,
   "requires_ecap": true,
-  "governing_issue": "#1219",
-  "scope_summary": "Reconcile the post-merge Stage 10 control surfaces with merged PR #1218, align the progress tracker, pre-build artifact index and Stage 10 pointer with the approved Stage 8 implementation plan, and preserve the boundary that Stage 11 requires separate CS2 authorization and Stage 12 remains blocked.",
+  "governing_issue": "#1223",
+  "scope_summary": "Formally appoint integration-builder for AMC W1 under Stage 11, bind the W1 contract and constitutional onboarding requirements, and preserve the boundary that no implementation begins before separate Stage 12 authorization.",
   "created_by": "foreman-v2-agent",
-  "created_at": "2026-07-23T11:51:23Z",
+  "created_at": "2026-07-23T13:01:32Z",
   "execution_model": "foreman-orchestrated",
   "orchestrating_agent": "foreman-v2-agent",
-  "implementing_agent": "none-postmerge-alignment-only"
+  "implementing_agent": "none-stage11-appointment-only"
 }

--- a/.agent-admin/prehandover/ecap-reconciliation-1224.md
+++ b/.agent-admin/prehandover/ecap-reconciliation-1224.md
@@ -1,0 +1,44 @@
+# ECAP Reconciliation Summary — PR #1224
+
+**Issue**: #1223  
+**PR**: #1224  
+**Branch**: `foreman/amc-stage11-w1-builder-appointment`  
+**ECAP Session**: `ecap-session-1224-20260723-r1`  
+**Administrative Verdict**: PASS  
+**Substantive Appointment Verdict**: BLOCKED — candidate acknowledgment pending
+
+protected_path_touched: true
+ecap_required: true
+ecap_invoked: true
+ecap_verdict: PASS
+ceremony_admin_appointed: true
+protected_path_ceremony_verdict: PASS
+
+## Administrative Scope
+
+ECAP reviewed the administrative ceremony and protected-path requirements for the Stage 11 appointment package.
+
+The current changed-path set contains governance and appointment artifacts only. No W1 implementation workflow, runtime code, migration, schema mutation, deployment action or Production setting is created.
+
+## Administrative Findings
+
+- Governing issue #1223 and PR #1224 are correctly linked.
+- `.admin/pr.json` identifies a governance-control Stage 11 appointment wave.
+- Appointment and W1 contract overlay exist.
+- Candidate acknowledgment carrier exists.
+- Progress tracker and pre-build artifact index reflect the real blocked state.
+- Ripple registry reflects active `integration-builder` contract v3.4.0.
+- Stage 12 remains blocked.
+- Implementation authority remains false.
+
+## Boundary
+
+ECAP does not author the candidate acknowledgment, issue independent assurance, appoint the builder, authorize Stage 12, or determine merge readiness.
+
+administrative_readiness: PASS  
+appointment_package_admin_record: COMPLETE  
+candidate_acknowledgment_present: false  
+stage_11_status: BLOCKED  
+builder_appointed: false  
+stage_12_authorized: false  
+implementation_authorized: false

--- a/.agent-admin/wave-records/amc-wave-record-stage11-w1-builder-appointment-1224.md
+++ b/.agent-admin/wave-records/amc-wave-record-stage11-w1-builder-appointment-1224.md
@@ -1,0 +1,102 @@
+# AMC Wave Record — Stage 11 W1 Builder Appointment
+
+## 1. Identity
+
+| Field | Value |
+|---|---|
+| Repository | `APGI-cmy/app_management_centre` |
+| Issue | #1223 |
+| PR | #1224 |
+| Branch | `foreman/amc-stage11-w1-builder-appointment` |
+| Wave | `amc-stage11-w1-builder-appointment-20260723` |
+| Orchestrating agent | `foreman-v2-agent` |
+| Candidate | `integration-builder` |
+| Candidate contract | `.github/agents/integration-builder.md` v3.4.0 |
+| Appointment target | W1 — Runtime Foundation and Environment Setup |
+| Entry condition | NORMAL — Stages 1–10 complete |
+
+## 2. Scope
+
+Prepare the complete constitutional Stage 11 appointment package for `integration-builder` without granting Stage 12 implementation authority.
+
+The package includes:
+
+- formal appointment instruction;
+- W1 contract overlay;
+- exact architecture and QA suite references;
+- verified RED target of nine mapped W1 obligations;
+- explicit path allowlist and prohibitions;
+- Ripple Intelligence confirmation;
+- OPOJD, One-Time Build Law, terminal-state, Zero Test Debt and PREHANDOVER_PROOF bindings;
+- candidate-owned acknowledgment carrier;
+- progress tracker and artifact-index alignment.
+
+## 3. Foreman Quality Review
+
+| Control | Result |
+|---|---|
+| Stages 1–10 complete | PASS |
+| Candidate readiness accepted | PASS |
+| Stage 10 pre-brief complete | PASS |
+| Appointment instruction complete | PASS |
+| QA Suite Location explicit | PASS |
+| RED target/count verified | PASS — 9 mapped obligations |
+| W1 scope and cross-wave mappings | PASS |
+| Exact writable-path allowlist | PASS |
+| Production/migration/credential prohibitions | PASS |
+| Ripple sync status | PASS — ALIGNED |
+| Ripple status | PASS — STABLE |
+| Contract registry version | PASS — v3.4.0 |
+| Stage 12 separation | PASS |
+| Candidate constitutional acknowledgment | BLOCKED — candidate response pending |
+
+## 4. Appointment Disposition
+
+`BLOCKED — CANDIDATE ACKNOWLEDGMENT REQUIRED`
+
+The Foreman may prepare and verify the appointment package but may not author or infer the candidate's mandatory Stage 11 acknowledgment.
+
+The acknowledgment carrier is:
+
+```text
+modules/amc/10-builder-appointment/integration-builder-stage11-acknowledgment.md
+```
+
+Until the candidate supplies the response and timestamp:
+
+- Stage 11 is incomplete;
+- `integration-builder` is not constitutionally appointed;
+- PR #1224 is not merge-ready;
+- Stage 12 remains blocked;
+- implementation authorization remains false.
+
+## 5. ECAP Ceremony
+
+protected_path_touched: true
+ecap_required: true
+ecap_invoked: true
+ecap_verdict: PASS
+ceremony_admin_appointed: true
+protected_path_ceremony_verdict: PASS
+ECAP session: ecap-session-1224-20260723-r1
+
+ECAP certifies administrative completeness only and does not override the acknowledgment blocker.
+
+## 6. Independent Assurance
+
+Issue: #1223
+PR: #1224
+Verdict: BLOCKED
+Adoption Phase: PHASE_B_BLOCKING
+Blocking condition: candidate-authored Stage 11 acknowledgment absent
+
+IAA may issue PASS only after the acknowledgment carrier contains an explicit candidate-authored response and timestamp and all final-head checks pass.
+
+## 7. Current Boundary
+
+- Stage 11 package preparation: COMPLETE.
+- Stage 11 appointment: BLOCKED pending candidate acknowledgment.
+- Builder appointed: false.
+- Stage 12 authorized: false.
+- Implementation authorized: false.
+- Runtime/workflow/migration/deployment mutation: false.

--- a/.agent-workspace/independent-assurance-agent/memory/session-1224-20260723.md
+++ b/.agent-workspace/independent-assurance-agent/memory/session-1224-20260723.md
@@ -1,0 +1,71 @@
+# IAA Session — PR #1224 — AMC Stage 11 W1 Builder Appointment
+
+Issue: #1223
+PR: #1224
+governing_issue: #1223
+Branch: foreman/amc-stage11-w1-builder-appointment
+Verdict: BLOCKED
+Adoption Phase: PHASE_B_BLOCKING
+Blocking Condition: mandatory candidate-authored Stage 11 acknowledgment absent
+
+## Assurance Scope
+
+Independent assurance reviewed the Stage 11 W1 appointment package for `integration-builder` against:
+
+- the canonical 12-stage lifecycle;
+- FM Builder Appointment Protocol;
+- mandatory appointment instruction template;
+- active `integration-builder` contract v3.4.0;
+- accepted Stage 9 readiness;
+- completed Stage 10 IAA pre-brief;
+- approved Stage 8 implementation plan and cross-wave mappings;
+- W1 RED-Test and Evidence Map;
+- tracker, artifact index and Ripple registry.
+
+## Findings
+
+1. Stages 1–10 are complete and provide a valid entry condition for Stage 11.
+2. The formal appointment instruction now identifies the exact architecture reference.
+3. The exact QA suite carrier is identified as `modules/amc/08-builder-checklist/executions/w1/w1-red-test-and-evidence-map.md`.
+4. The Foreman verified nine mapped W1 RED obligations: seven named QA-DEPLOY controls plus applicable QA-CONFIG and QA-DES controls.
+5. The W1 contract overlay defines a concrete writable-path allowlist and read-only authority paths.
+6. Production, migration, credential, test-weakening, self-approval and self-merge prohibitions are explicit.
+7. Stage 8 mappings are preserved: `ci.yml` W1/W8, `deploy-frontend.yml` W1/W7, `db-migrate.yml` W7.
+8. Ripple sync is `ALIGNED`, Ripple status is `STABLE`, and the contract registry now reflects v3.4.0.
+9. Progress tracker and artifact index truthfully show Stage 11 blocked and Stage 12 unauthorized.
+10. The candidate acknowledgment carrier exists but still contains `CANDIDATE RESPONSE: PENDING` and no candidate timestamp.
+
+## Blocking Determination
+
+The FM Builder Appointment Protocol states that appointment is incomplete until the builder explicitly acknowledges the constitutional operating model. The Foreman, ECAP and IAA may not author or infer that acknowledgment on the candidate's behalf.
+
+Therefore:
+
+```text
+Stage 11 verdict: BLOCKED
+Blocker: candidate-authored acknowledgment missing
+Builder appointed: false
+Stage 12 authorized: false
+Implementation authorized: false
+```
+
+## Required Closure Evidence
+
+To close the blocker, `integration-builder` must update:
+
+```text
+modules/amc/10-builder-appointment/integration-builder-stage11-acknowledgment.md
+```
+
+with:
+
+- explicit acknowledgment of all twelve requirements;
+- candidate identity;
+- candidate-authored timestamp;
+- no changes to appointment scope or Stage 12 boundary.
+
+After that update, Foreman must re-review the final head, ECAP must refresh the administrative record, and IAA must issue a new PASS token bound to the acknowledged final state.
+
+## Final Boundary
+
+No builder appointment is certified by this record. No implementation may begin. Stage 12 remains blocked.

--- a/governance/alignment/canonical_sync_status.json
+++ b/governance/alignment/canonical_sync_status.json
@@ -36,10 +36,10 @@
       "alignment_status": "CURRENT"
     },
     "integration-builder": {
-      "contract_version": "2.0.0",
+      "contract_version": "3.4.0",
       "doctrine_version": "1.0.0",
       "ripple_aware": true,
-      "last_verified": "2026-01-02T10:40:00Z",
+      "last_verified": "2026-07-23T13:20:00Z",
       "alignment_status": "CURRENT"
     },
     "qa-builder": {

--- a/modules/amc/10-builder-appointment/builder-appointment.md
+++ b/modules/amc/10-builder-appointment/builder-appointment.md
@@ -6,16 +6,24 @@
 **Builder**: `integration-builder`  
 **Builder Class**: Integration Builder  
 **Governing Issue**: #1223  
-**Status**: 🟡 APPOINTMENT PROPOSED — authoritative only after merge and CS2 acceptance  
-**Execution State After Acceptance**: `APPOINTED — AWAITING STAGE 12 AUTHORIZATION`
+**Governing PR**: #1224  
+**Status**: 🟠 APPOINTMENT PACKAGE COMPLETE — BLOCKED PENDING BUILDER ACKNOWLEDGMENT  
+**Intended Post-Acceptance State**: `APPOINTED — AWAITING STAGE 12 AUTHORIZATION`
 
 ---
 
 ## 1. Appointment Authority
 
-The Foreman formally appoints `integration-builder` to W1 subject to merge and CS2 acceptance of the Stage 11 PR.
+CS2 has authorized the Foreman to prepare the formal W1 appointment of `integration-builder`.
 
-This appointment establishes constitutional role, scope, accountability, and operating constraints. It does **not** authorize implementation. The builder may not begin W1 execution until a separate Stage 12 issue explicitly grants Build-to-Green authority.
+The appointment becomes constitutionally complete only when all of the following are true:
+
+1. the Stage 11 appointment package is complete;
+2. the builder has supplied the explicit Stage 11 acknowledgment required by the FM Builder Appointment Protocol;
+3. independent assurance confirms the appointment package and acknowledgment;
+4. PR #1224 is merged and accepted by CS2.
+
+This Stage 11 package does **not** authorize implementation. No W1 execution may begin until a separate Stage 12 issue explicitly grants Build-to-Green authority.
 
 ## 2. Binding Sources
 
@@ -28,6 +36,7 @@ This appointment establishes constitutional role, scope, accountability, and ope
 - `modules/amc/07-implementation-plan/wave-breakdown.md`
 - `modules/amc/07-implementation-plan/condition-import-matrix.md`
 - `modules/amc/08-builder-checklist/executions/w1/integration-builder-readiness-checklist.md`
+- `modules/amc/08-builder-checklist/executions/w1/w1-red-test-and-evidence-map.md`
 - `.agent-admin/assurance/iaa-wave-record-amc-w1-runtime-foundation.md`
 
 ## 3. Appointment Instruction
@@ -40,10 +49,23 @@ Build Wave: W1
 
 BUILD TO GREEN
 
-Architecture Reference: `modules/amc/04-architecture/architecture-specification.md`  
-QA Authority: `modules/amc/05-qa-to-red/qa-to-red-specification.md` and W1 RED/evidence map  
-QA Current Status: RED obligations defined; implementation proof not yet produced  
-Acceptance Criteria: All applicable W1 QA and governance gates must pass at 100%
+Architecture Reference: `/modules/amc/04-architecture/architecture-specification.md`  
+QA Suite Location: `/modules/amc/08-builder-checklist/executions/w1/w1-red-test-and-evidence-map.md`  
+QA Current Status: RED — 9 mapped W1 obligations unresolved: 7 named QA-DEPLOY controls plus applicable QA-CONFIG and QA-DES controls  
+RED Count Verification: Foreman verified the nine rows in the W1 RED-Test and Evidence Map on 2026-07-23  
+Acceptance Criteria: All 9 mapped W1 obligations and every applicable repository gate must pass at 100%; zero test debt and zero warnings
+
+The nine W1 RED obligations are:
+
+1. `QA-DEPLOY-001`
+2. `QA-DEPLOY-002`
+3. `QA-DEPLOY-003`
+4. `QA-DEPLOY-004`
+5. `QA-DEPLOY-006`
+6. `QA-DEPLOY-007`
+7. `QA-DEPLOY-010`
+8. applicable QA-CONFIG controls
+9. applicable QA-DES controls
 
 ## 4. Scope Boundaries
 
@@ -56,15 +78,15 @@ Acceptance Criteria: All applicable W1 QA and governance gates must pass at 100%
 - Prove Vercel Preview uses the approved non-production Supabase `develop` resource.
 - Prove Production credentials are unavailable to PR and Preview jobs.
 - Prove no PR or Preview path can deploy to or mutate Production.
-- Produce W1 RED-to-GREEN and PREHANDOVER_PROOF evidence.
-- Update approved W1 evidence, tracker, and index surfaces as part of the later build handover.
+- Produce W1 RED-to-GREEN and PREHANDOVER_PROOF evidence in the exact Stage 12 evidence surfaces.
+- Update the approved tracker and artifact index during the later Stage 12 handover.
 
 ### What is not in scope
 
 - `db-migrate.yml`, which remains W7 scope.
 - Database schema changes or Production migrations.
 - Direct Production deployment or configuration mutation.
-- Architecture, FRS, TRS, QA, or governance redesign.
+- Architecture, FRS, TRS, QA, PBFAG, or governance redesign.
 - Test removal, weakening, bypass, dilution, or debt.
 - Work belonging to W2–W8 except preserving the approved cross-wave mappings.
 - Any implementation before separate Stage 12 authorization.
@@ -88,21 +110,43 @@ The builder is explicitly bound to:
 7. Immediate STOP and escalation when authority, architecture, environment, credentials, scope, or evidence is ambiguous.
 8. Foreman supervision and independent IAA review.
 
-## 7. Required Builder Acknowledgment
+## 7. Ripple Intelligence Alignment Confirmation
 
-Before Stage 12 authority may be granted, the builder must explicitly acknowledge:
+Governance Canon Version: `1.0.0` from `governance/alignment/canonical_sync_status.json`  
+Last Canonical Sync: `2026-01-02T10:40:00Z`  
+Verification Date: `2026-07-23`  
+Sync Status: `ALIGNED`  
+Ripple Status: `STABLE`  
+Active Builder Contract: `.github/agents/integration-builder.md` v3.4.0  
+Alignment Registry Entry: updated to v3.4.0 in PR #1224  
+Canonical Authorities Current: YES
 
-- OPOJD continuous execution;
-- `BLOCKED` or `COMPLETE` terminal-state discipline;
-- One-Time Build Law;
-- 100% GREEN and zero test debt;
-- all STOP and escalation conditions;
-- Execution Bootstrap Protocol and PREHANDOVER_PROOF;
-- the prohibition on Production credentials, Production mutation, and premature implementation.
+Confirmation Statement:
 
-The Stage 9 attestation supports readiness but does not replace this Stage 11 constitutional acknowledgment.
+- [x] Builder agent contract reflects current Ripple Intelligence obligations.
+- [x] Builder scope is explicitly bound to `APGI-cmy/app_management_centre`.
+- [x] Governance sync status is `ALIGNED`.
+- [x] Ripple status is `STABLE` with no active or pending ripple.
+- [x] No ripple ambiguity remains after the v3.4.0 alignment-registry correction.
+- [x] Appointment preparation may proceed with governance-current context.
 
-## 8. Stop and Escalation Conditions
+FM declares: Ripple Intelligence Alignment = CONFIRMED.
+
+## 8. Builder Acknowledgment
+
+The Stage 9 candidate attestation confirms readiness but does not substitute for the mandatory Stage 11 constitutional acknowledgment.
+
+The exact acknowledgment request and response carrier is:
+
+```text
+modules/amc/10-builder-appointment/integration-builder-stage11-acknowledgment.md
+```
+
+Current acknowledgment status: `PENDING CANDIDATE RESPONSE`.
+
+Until the candidate supplies the explicit response in that carrier, Stage 11 remains incomplete and PR #1224 must not be treated as merge-ready.
+
+## 9. Stop and Escalation Conditions
 
 The builder must STOP and report `BLOCKED` when:
 
@@ -115,15 +159,15 @@ The builder must STOP and report `BLOCKED` when:
 - execution complexity exceeds practical capability;
 - evidence cannot be reproduced.
 
-Escalation must state: category, severity, trigger, canonical references, context, and resolution options.
+Escalation must state: category, severity, trigger, canonical references, context, resolution options, and recommended safe next action.
 
-## 9. Supervision
+## 10. Supervision
 
 The Foreman retains non-delegable responsibility for scope control, active supervision, intervention, quality validation, review closure, gate verification, and handover to IAA.
 
-## 10. Appointment Boundary
+## 11. Appointment Boundary
 
-Upon merge and CS2 acceptance:
+Only after builder acknowledgment, independent assurance, merge, and CS2 acceptance may the state become:
 
 ```text
 Builder state: APPOINTED — AWAITING STAGE 12 AUTHORIZATION
@@ -131,4 +175,4 @@ Implementation authorized: false
 Stage 12 status: BLOCKED
 ```
 
-No “begin execution” instruction is issued in Stage 11. Execution-grant language from the generic appointment protocol is deferred to the separate Stage 12 authorization so the canonical 12-stage sequence remains intact.
+No “begin execution” instruction is issued in Stage 11. Execution-grant language is deferred to the separate Stage 12 authorization so the canonical 12-stage sequence remains intact.

--- a/modules/amc/10-builder-appointment/builder-appointment.md
+++ b/modules/amc/10-builder-appointment/builder-appointment.md
@@ -2,17 +2,133 @@
 
 **Stage**: 11 — Builder Appointment  
 **Module**: App Management Centre (AMC)  
-**Status**: ⬜ Not Started  
-**Prerequisite**: Stage 10 (IAA Pre-Brief) complete
+**Wave**: W1 — Runtime Foundation and Environment Setup  
+**Builder**: `integration-builder`  
+**Builder Class**: Integration Builder  
+**Governing Issue**: #1223  
+**Status**: 🟡 APPOINTMENT PROPOSED — authoritative only after merge and CS2 acceptance  
+**Execution State After Acceptance**: `APPOINTED — AWAITING STAGE 12 AUTHORIZATION`
 
 ---
 
-## Purpose
+## 1. Appointment Authority
 
-Foreman formally appoints builders with scoped issues, specifying wave, tasks, acceptance criteria, and merge gate requirements.
+The Foreman formally appoints `integration-builder` to W1 subject to merge and CS2 acceptance of the Stage 11 PR.
 
----
+This appointment establishes constitutional role, scope, accountability, and operating constraints. It does **not** authorize implementation. The builder may not begin W1 execution until a separate Stage 12 issue explicitly grants Build-to-Green authority.
 
-## Status
+## 2. Binding Sources
 
-Placeholder. Not started.
+- `governance/canon/PRE_BUILD_STAGE_MODEL_CANON.md`
+- `governance/canon/FM_BUILDER_APPOINTMENT_PROTOCOL.md`
+- `governance/templates/FM_BUILDER_APPOINTMENT_INSTRUCTION.template.md`
+- `governance/ROLE_APPOINTMENT_PROTOCOL.md`
+- `.github/agents/integration-builder.md`
+- `modules/amc/07-implementation-plan/implementation-plan.md`
+- `modules/amc/07-implementation-plan/wave-breakdown.md`
+- `modules/amc/07-implementation-plan/condition-import-matrix.md`
+- `modules/amc/08-builder-checklist/executions/w1/integration-builder-readiness-checklist.md`
+- `.agent-admin/assurance/iaa-wave-record-amc-w1-runtime-foundation.md`
+
+## 3. Appointment Instruction
+
+APPOINTMENT: INTEGRATION-BUILDER
+
+Role: Integration Builder  
+Task ID: AMC-W1-RUNTIME-FOUNDATION  
+Build Wave: W1
+
+BUILD TO GREEN
+
+Architecture Reference: `modules/amc/04-architecture/architecture-specification.md`  
+QA Authority: `modules/amc/05-qa-to-red/qa-to-red-specification.md` and W1 RED/evidence map  
+QA Current Status: RED obligations defined; implementation proof not yet produced  
+Acceptance Criteria: All applicable W1 QA and governance gates must pass at 100%
+
+## 4. Scope Boundaries
+
+### What is in scope after Stage 12 authorization
+
+- Implement `.github/workflows/ci.yml`.
+- Implement `.github/workflows/deploy-frontend.yml`.
+- Validate or update root `.env.example` without secret values.
+- Prove CI/type/lint/test/schema enforcement.
+- Prove Vercel Preview uses the approved non-production Supabase `develop` resource.
+- Prove Production credentials are unavailable to PR and Preview jobs.
+- Prove no PR or Preview path can deploy to or mutate Production.
+- Produce W1 RED-to-GREEN and PREHANDOVER_PROOF evidence.
+- Update approved W1 evidence, tracker, and index surfaces as part of the later build handover.
+
+### What is not in scope
+
+- `db-migrate.yml`, which remains W7 scope.
+- Database schema changes or Production migrations.
+- Direct Production deployment or configuration mutation.
+- Architecture, FRS, TRS, QA, or governance redesign.
+- Test removal, weakening, bypass, dilution, or debt.
+- Work belonging to W2–W8 except preserving the approved cross-wave mappings.
+- Any implementation before separate Stage 12 authorization.
+
+## 5. Cross-Wave Mapping
+
+- `ci.yml` is introduced in W1 and remains subject to W8 consolidation and validation.
+- `deploy-frontend.yml` is introduced in W1 and remains subject to W7 deployment-execution validation.
+- `db-migrate.yml` remains a W7 output.
+
+## 6. Constitutional Onboarding
+
+The builder is explicitly bound to:
+
+1. OPOJD continuous execution during an authorized build cycle.
+2. Terminal states only: `BLOCKED` or `COMPLETE`.
+3. One-Time Build Law and first-delivery completeness.
+4. 100% QA GREEN, zero test debt, and zero-warning discipline.
+5. Architecture-as-Law and active Design Freeze.
+6. Execution Bootstrap Protocol and PREHANDOVER_PROOF.
+7. Immediate STOP and escalation when authority, architecture, environment, credentials, scope, or evidence is ambiguous.
+8. Foreman supervision and independent IAA review.
+
+## 7. Required Builder Acknowledgment
+
+Before Stage 12 authority may be granted, the builder must explicitly acknowledge:
+
+- OPOJD continuous execution;
+- `BLOCKED` or `COMPLETE` terminal-state discipline;
+- One-Time Build Law;
+- 100% GREEN and zero test debt;
+- all STOP and escalation conditions;
+- Execution Bootstrap Protocol and PREHANDOVER_PROOF;
+- the prohibition on Production credentials, Production mutation, and premature implementation.
+
+The Stage 9 attestation supports readiness but does not replace this Stage 11 constitutional acknowledgment.
+
+## 8. Stop and Escalation Conditions
+
+The builder must STOP and report `BLOCKED` when:
+
+- architecture or QA authority is missing, inconsistent, or ambiguous;
+- required access or environment binding is unavailable;
+- Production credentials or mutation paths appear in PR/Preview scope;
+- work requires paths or capabilities outside W1;
+- any gate or RED obligation fails;
+- a secret may have been exposed;
+- execution complexity exceeds practical capability;
+- evidence cannot be reproduced.
+
+Escalation must state: category, severity, trigger, canonical references, context, and resolution options.
+
+## 9. Supervision
+
+The Foreman retains non-delegable responsibility for scope control, active supervision, intervention, quality validation, review closure, gate verification, and handover to IAA.
+
+## 10. Appointment Boundary
+
+Upon merge and CS2 acceptance:
+
+```text
+Builder state: APPOINTED — AWAITING STAGE 12 AUTHORIZATION
+Implementation authorized: false
+Stage 12 status: BLOCKED
+```
+
+No “begin execution” instruction is issued in Stage 11. Execution-grant language from the generic appointment protocol is deferred to the separate Stage 12 authorization so the canonical 12-stage sequence remains intact.

--- a/modules/amc/10-builder-appointment/builder-contract.md
+++ b/modules/amc/10-builder-appointment/builder-contract.md
@@ -4,9 +4,10 @@
 **Module**: App Management Centre (AMC)  
 **Wave**: W1 — Runtime Foundation and Environment Setup  
 **Builder**: `integration-builder`  
-**Source Contract**: `.github/agents/integration-builder.md`  
+**Source Contract**: `.github/agents/integration-builder.md` v3.4.0  
 **Governing Issue**: #1223  
-**Status**: 🟡 PROPOSED W1 CONTRACT OVERLAY — binding after merge and CS2 acceptance
+**Governing PR**: #1224  
+**Status**: 🟠 W1 CONTRACT OVERLAY COMPLETE — binding only after acknowledgment, merge and CS2 acceptance
 
 ---
 
@@ -16,7 +17,7 @@ This W1 overlay narrows the existing `integration-builder` contract to the exact
 
 ## 2. Authority and Execution State
 
-The builder is appointed for W1 only. After Stage 11 acceptance its state is:
+The intended post-acceptance state is:
 
 ```text
 APPOINTED — AWAITING STAGE 12 AUTHORIZATION
@@ -24,24 +25,47 @@ APPOINTED — AWAITING STAGE 12 AUTHORIZATION
 
 The builder has no authority to execute, modify implementation files, run migrations, deploy, or change infrastructure until a separate Stage 12 authorization is issued.
 
-## 3. Allowed W1 Paths After Stage 12 Authorization
+## 3. Exact Allowed W1 Paths After Stage 12 Authorization
+
+The builder may modify only the following implementation and evidence paths unless the Foreman explicitly expands scope in the Stage 12 issue:
 
 - `.github/workflows/ci.yml`
 - `.github/workflows/deploy-frontend.yml`
 - `.env.example`
-- approved W1 test/evidence paths
-- `modules/amc/11-build/` evidence surfaces
+- `modules/amc/11-build/build-evidence-index.md`
+- `modules/amc/11-build/qa-to-green-evidence.md`
+- `modules/amc/11-build/handover.md`
 - `modules/amc/BUILD_PROGRESS_TRACKER.md`
 - `modules/amc/AMC_PRE_BUILD_ARTIFACT_INDEX.md`
-- PR administration and evidence files required by repository gates
+- `.admin/pr.json`
+- `.agent-admin/prehandover/ecap-reconciliation-<stage12-pr>.md`
+- `.agent-admin/wave-records/amc-wave-record-stage12-w1-<stage12-pr>.md`
+- `.agent-workspace/independent-assurance-agent/memory/session-<stage12-pr>-<date>.md`
 
-Any other path requires explicit Foreman confirmation or escalation before modification.
+The builder may read but must not modify the following authority and test-definition paths:
+
+- `modules/amc/00-app-description/`
+- `modules/amc/01-ux-workflow-wiring-spec/`
+- `modules/amc/02-frs/`
+- `modules/amc/03-trs/`
+- `modules/amc/04-architecture/`
+- `modules/amc/05a-deployment-execution-strategy/`
+- `modules/amc/05-qa-to-red/`
+- `modules/amc/06-pbfag/`
+- `modules/amc/07-implementation-plan/`
+- `modules/amc/08-builder-checklist/`
+- `modules/amc/09-iaa-pre-brief/`
+- `modules/amc/10-builder-appointment/`
+- `governance/`
+- `.github/agents/`
+
+Any path not expressly listed as writable is out of scope and requires STOP-and-escalate before modification.
 
 ## 4. Restricted and Prohibited Paths/Actions
 
 The builder must not:
 
-- create or modify `db-migrate.yml` in W1;
+- create or modify `.github/workflows/db-migrate.yml` in W1;
 - alter Supabase schemas or run Production migrations;
 - expose or consume Production credentials in PR/Preview execution;
 - create a direct Production deployment path;
@@ -89,7 +113,7 @@ The builder commits to:
 
 W1 may be handed over only when:
 
-- every applicable W1 RED obligation is GREEN;
+- all nine mapped W1 RED obligations are GREEN;
 - all required workflows and configuration surfaces exist and are executable;
 - every required check is green on the final implementation head;
 - Preview/non-production and Production boundaries are separately inspected;
@@ -132,18 +156,27 @@ The builder produces implementation and evidence only. It does not perform Forem
 
 ## 12. Stage 11 Acknowledgment Requirement
 
-Before Stage 12 authorization, `integration-builder` must explicitly acknowledge each of the following:
+The candidate-owned acknowledgment carrier is:
+
+```text
+modules/amc/10-builder-appointment/integration-builder-stage11-acknowledgment.md
+```
+
+Stage 11 cannot complete until the candidate explicitly acknowledges:
 
 1. OPOJD continuous execution.
 2. `BLOCKED` or `COMPLETE` terminal states only.
 3. One-Time Build Law and 100% GREEN.
 4. Zero test debt and zero warnings.
-5. STOP and escalation conditions.
-6. Execution Bootstrap Protocol and PREHANDOVER_PROOF.
-7. W1 scope and cross-wave boundaries.
-8. No Production credentials, mutation, migration, or direct deployment.
-9. No implementation before Stage 12 authorization.
+5. Architecture-as-Law and Design Freeze.
+6. All nine mapped W1 RED obligations.
+7. STOP and escalation conditions.
+8. Execution Bootstrap Protocol and PREHANDOVER_PROOF.
+9. The exact path allowlist and cross-wave boundaries.
+10. No Production credentials, mutation, migration, direct deployment, or premature implementation.
+11. Foreman supervision and independent IAA review.
+12. No self-approval, self-merge, test weakening, or false GREEN claims.
 
 ## 13. Contract Disposition
 
-This overlay becomes binding only when the Stage 11 PR is merged and accepted by CS2. Until then, the builder remains nominated/readiness-approved but not appointed.
+This overlay becomes binding only when the acknowledgment is candidate-authored, independently verified, PR #1224 is merged, and CS2 accepts the Stage 11 appointment. Until then, the candidate remains readiness-approved but not constitutionally appointed.

--- a/modules/amc/10-builder-appointment/builder-contract.md
+++ b/modules/amc/10-builder-appointment/builder-contract.md
@@ -2,16 +2,148 @@
 
 **Stage**: 11 — Builder Appointment  
 **Module**: App Management Centre (AMC)  
-**Status**: ⬜ Not Started
+**Wave**: W1 — Runtime Foundation and Environment Setup  
+**Builder**: `integration-builder`  
+**Source Contract**: `.github/agents/integration-builder.md`  
+**Governing Issue**: #1223  
+**Status**: 🟡 PROPOSED W1 CONTRACT OVERLAY — binding after merge and CS2 acceptance
 
 ---
 
-## Purpose
+## 1. Contract Purpose
 
-This document formalizes the builder contract for appointed AMC builders, specifying scope boundaries, governance constraints, acceptance criteria, and merge gate requirements.
+This W1 overlay narrows the existing `integration-builder` contract to the exact AMC W1 appointment. It supplements but does not replace the canonical builder contract.
 
----
+## 2. Authority and Execution State
 
-## Status
+The builder is appointed for W1 only. After Stage 11 acceptance its state is:
 
-Placeholder. Not started.
+```text
+APPOINTED — AWAITING STAGE 12 AUTHORIZATION
+```
+
+The builder has no authority to execute, modify implementation files, run migrations, deploy, or change infrastructure until a separate Stage 12 authorization is issued.
+
+## 3. Allowed W1 Paths After Stage 12 Authorization
+
+- `.github/workflows/ci.yml`
+- `.github/workflows/deploy-frontend.yml`
+- `.env.example`
+- approved W1 test/evidence paths
+- `modules/amc/11-build/` evidence surfaces
+- `modules/amc/BUILD_PROGRESS_TRACKER.md`
+- `modules/amc/AMC_PRE_BUILD_ARTIFACT_INDEX.md`
+- PR administration and evidence files required by repository gates
+
+Any other path requires explicit Foreman confirmation or escalation before modification.
+
+## 4. Restricted and Prohibited Paths/Actions
+
+The builder must not:
+
+- create or modify `db-migrate.yml` in W1;
+- alter Supabase schemas or run Production migrations;
+- expose or consume Production credentials in PR/Preview execution;
+- create a direct Production deployment path;
+- change approved architecture, FRS, TRS, QA-to-Red, PBFAG, or governance canon;
+- edit its own agent contract;
+- remove, skip, mute, weaken, or reclassify tests or gates;
+- accept warnings, flaky tests, deferred work, placeholders, stubs, or test debt;
+- operate outside W1;
+- merge its own PR;
+- claim GREEN or completion without reproducible evidence and Foreman validation.
+
+## 5. Build Philosophy Binding
+
+The builder commits to:
+
+- Architecture → QA-to-Red → Build-to-Green → Validation;
+- One-Time Build Law;
+- OPOJD continuous execution once Stage 12 begins;
+- terminal states `BLOCKED` or `COMPLETE` only;
+- 100% GREEN, zero test debt, zero warnings;
+- CI as confirmatory, not diagnostic;
+- stop-and-fix on every defect;
+- PREHANDOVER_PROOF for executable artifacts.
+
+## 6. W1 Deliverables After Stage 12 Authorization
+
+1. `ci.yml` with explicit triggers, permissions, required checks, and non-production-safe behavior.
+2. `deploy-frontend.yml` with Preview/staging posture and protected Production behavior.
+3. Validated or updated `.env.example` containing names/placeholders only, never secret values.
+4. CI/type/lint/test/schema evidence.
+5. Preview deployment evidence.
+6. Proof Preview binds to Supabase `develop`.
+7. Proof Production credentials are unavailable to PR/Preview jobs.
+8. Proof PR/Preview work cannot deploy or mutate Production.
+9. No-Production-side-effect evidence.
+10. W1 RED-to-GREEN traceability and PREHANDOVER_PROOF.
+
+## 7. Cross-Wave Obligations
+
+- `ci.yml` is introduced and proven in W1, then consolidated/validated in W8.
+- `deploy-frontend.yml` is introduced and proven in W1, then deployment-execution validated in W7.
+- `db-migrate.yml` is created only in W7.
+
+## 8. Acceptance Criteria
+
+W1 may be handed over only when:
+
+- every applicable W1 RED obligation is GREEN;
+- all required workflows and configuration surfaces exist and are executable;
+- every required check is green on the final implementation head;
+- Preview/non-production and Production boundaries are separately inspected;
+- no secret value is exposed;
+- no Production side effect occurred;
+- no unresolved review conversation remains;
+- no scope drift, test debt, warning debt, placeholder, or deferred item exists;
+- evidence is complete, reproducible, and bound to the final head;
+- Foreman quality control passes;
+- independent IAA assurance passes.
+
+## 9. STOP Conditions
+
+The builder must immediately stop and escalate when:
+
+- scope, architecture, QA, or governance is ambiguous;
+- an allowed-path boundary would be exceeded;
+- required credentials or environment bindings are unavailable;
+- Production credentials or mutation routes are visible;
+- any test or gate fails;
+- secret exposure is suspected;
+- execution cannot be completed to 100% GREEN;
+- practical capability or platform limits are reached.
+
+## 10. Escalation Format
+
+Every `BLOCKED` escalation must include:
+
+- Category
+- Severity
+- Trigger
+- Canonical references
+- Exact context/evidence
+- Resolution options
+- Recommended safe next action
+
+## 11. Foreman and IAA Boundary
+
+The builder produces implementation and evidence only. It does not perform Foreman QP, issue ECAP judgments, issue independent IAA findings, approve its own work, or release merge authority.
+
+## 12. Stage 11 Acknowledgment Requirement
+
+Before Stage 12 authorization, `integration-builder` must explicitly acknowledge each of the following:
+
+1. OPOJD continuous execution.
+2. `BLOCKED` or `COMPLETE` terminal states only.
+3. One-Time Build Law and 100% GREEN.
+4. Zero test debt and zero warnings.
+5. STOP and escalation conditions.
+6. Execution Bootstrap Protocol and PREHANDOVER_PROOF.
+7. W1 scope and cross-wave boundaries.
+8. No Production credentials, mutation, migration, or direct deployment.
+9. No implementation before Stage 12 authorization.
+
+## 13. Contract Disposition
+
+This overlay becomes binding only when the Stage 11 PR is merged and accepted by CS2. Until then, the builder remains nominated/readiness-approved but not appointed.

--- a/modules/amc/10-builder-appointment/integration-builder-stage11-acknowledgment.md
+++ b/modules/amc/10-builder-appointment/integration-builder-stage11-acknowledgment.md
@@ -1,0 +1,60 @@
+# Integration Builder — Stage 11 Constitutional Acknowledgment
+
+**Stage**: 11 — Builder Appointment  
+**Module**: App Management Centre (AMC)  
+**Wave**: W1 — Runtime Foundation and Environment Setup  
+**Candidate**: `integration-builder`  
+**Governing Issue**: #1223  
+**Governing PR**: #1224  
+**Status**: ⬜ PENDING CANDIDATE RESPONSE
+
+---
+
+## Foreman Acknowledgment Request
+
+Before the Stage 11 appointment may be completed, `integration-builder` must explicitly acknowledge and commit to each requirement below.
+
+1. OPOJD continuous execution after Stage 12 authorization, with no mid-build approval pauses.
+2. Terminal-state execution: `BLOCKED` or `COMPLETE` only.
+3. One-Time Build Law and 100% GREEN first delivery.
+4. Zero test debt and zero warnings.
+5. Architecture-as-Law and Design Freeze.
+6. The nine mapped W1 RED obligations in `modules/amc/08-builder-checklist/executions/w1/w1-red-test-and-evidence-map.md`.
+7. Execution Bootstrap Protocol and PREHANDOVER_PROOF.
+8. STOP and escalation conditions in the Stage 11 appointment and W1 contract overlay.
+9. W1 path allowlist and cross-wave boundaries.
+10. No Production credentials, Production mutation, schema migration, direct Production deployment, or implementation before Stage 12 authorization.
+11. Foreman supervision and independent IAA review.
+12. Prohibition on self-approval, self-merge, test weakening, or false GREEN claims.
+
+## Required Candidate Response
+
+The candidate must replace the placeholder below with an explicit candidate-authored response and timestamp.
+
+```text
+CANDIDATE RESPONSE: PENDING
+
+I, integration-builder, acknowledge and commit to:
+1. OPOJD continuous execution after Stage 12 authorization.
+2. BLOCKED or COMPLETE terminal states only.
+3. One-Time Build Law and 100% GREEN first delivery.
+4. Zero test debt and zero warnings.
+5. Architecture-as-Law and Design Freeze.
+6. All nine mapped W1 RED obligations.
+7. Execution Bootstrap Protocol and PREHANDOVER_PROOF.
+8. All STOP and escalation conditions.
+9. The explicit W1 path allowlist and cross-wave boundaries.
+10. No Production credentials, Production mutation, migration, direct Production deployment, or premature implementation.
+11. Foreman supervision and independent IAA review.
+12. No self-approval, self-merge, test weakening, or false GREEN claims.
+
+I understand these are constitutional requirements, not preferences.
+I understand this acknowledgment does not authorize Stage 12 execution.
+
+Candidate: integration-builder
+Timestamp: PENDING
+```
+
+## Appointment Gate
+
+Stage 11 status remains `BLOCKED — ACKNOWLEDGMENT PENDING` until the candidate-authored response and timestamp are committed and independently verified.

--- a/modules/amc/AMC_PRE_BUILD_ARTIFACT_INDEX.md
+++ b/modules/amc/AMC_PRE_BUILD_ARTIFACT_INDEX.md
@@ -2,7 +2,7 @@
 
 **Module**: App Management Centre (AMC)  
 **Lifecycle Model**: 12-Stage Pre-Build Sequence + Stage 5a (`PRE_BUILD_STAGE_MODEL_CANON.md` v1.0.0; AMC-GOV-OVERSIGHT-001)  
-**Last Updated**: 2026-07-23 (Merged PR #1218 completed the W1 Stage 10 IAA Pre-Brief. Issue #1219 / PR #1220 reconciles post-merge control metadata and confirms Stage 11 as the next eligible, separately authorized stage.)  
+**Last Updated**: 2026-07-23 (Issue #1223 / PR #1224 contains the complete W1 Stage 11 appointment package. Appointment remains blocked pending the mandatory candidate-authored acknowledgment. Stage 12 is not authorized.)  
 **Authority**: Maturion Foreman / CS2
 
 ---
@@ -145,7 +145,7 @@ This index catalogs all pre-build artifacts for the AMC module, mapped to their 
 | W1 Access Boundary Evidence | `modules/amc/08-builder-checklist/executions/w1/w1-access-boundary-evidence-20260722.md` | ✅ PASS AS READINESS ARRANGEMENT | Actual consumption remains W1 build evidence. |
 | W1 Environment Isolation Record | `modules/amc/08-builder-checklist/executions/w1/w1-environment-isolation-record-20260722.md` | ✅ PASS AS DESIGN/POLICY READINESS | Executed enforcement remains mandatory W1/W7 evidence. |
 | W1 Foreman Role-Fit Assessment | `modules/amc/08-builder-checklist/executions/w1/w1-foreman-role-fit-20260722.md` | ✅ PASS | Candidate fit confirmed. |
-| W1 RED-Test and Evidence Map | `modules/amc/08-builder-checklist/executions/w1/w1-red-test-and-evidence-map.md` | ✅ Defined / Binding for W1 | All RED and build-exit obligations retained. |
+| W1 RED-Test and Evidence Map | `modules/amc/08-builder-checklist/executions/w1/w1-red-test-and-evidence-map.md` | ✅ Defined / Binding for W1 | Nine mapped W1 obligations retained. |
 | W1 Readiness Reconciliation | `modules/amc/08-builder-checklist/executions/w1/w1-readiness-reconciliation-20260722.md` | 📦 Historical — BLOCKED | PR #1209 provenance. |
 | CS2 Decision Record — Stage 9 W1 (historical) | `modules/amc/08-builder-checklist/cs2-decision-record-stage-9-w1.md` | 📦 Historical — BLOCKED | Retained as provenance. |
 | Stage 9 W1 Bootstrap Correction Decision | `modules/amc/08-builder-checklist/cs2-decision-record-stage-9-w1-bootstrap-correction-20260723.md` | ✅ Accepted by merge | PR #1216 merged. |
@@ -164,7 +164,7 @@ Stage 9 W1 candidate readiness is **PASS ACCEPTED**. This is pre-appointment rea
 | Stage 10 IAA Memory | `.agent-workspace/independent-assurance-agent/memory/session-1218-20260723.md` | ✅ PASS | Final assurance token `IAA-session-1218-R2-20260723-PASS`. |
 | Stage 10 ECAP Reconciliation | `.agent-admin/prehandover/ecap-reconciliation-1218.md` | ✅ PASS | Protected-path ceremony record for merged PR #1218. |
 
-Stage 10 is **COMPLETE**. The W1 pre-brief is accepted and suitable for Stage 11 consideration. No builder is appointed and no implementation is authorized.
+Stage 10 is **COMPLETE**. The W1 pre-brief is accepted and suitable for Stage 11 consideration. No implementation is authorized.
 
 ---
 
@@ -172,8 +172,12 @@ Stage 10 is **COMPLETE**. The W1 pre-brief is accepted and suitable for Stage 11
 
 | Artifact | Location | Status | Notes |
 |---|---|---|---|
-| Builder Appointment | `modules/amc/10-builder-appointment/builder-appointment.md` | ⬜ Placeholder — 🟡 Eligible pending explicit CS2 authorization | `integration-builder` remains nominated/readiness-approved but not appointed. |
-| Builder Contract | `modules/amc/10-builder-appointment/builder-contract.md` | ⬜ Placeholder — 🟡 Eligible pending explicit CS2 authorization | Must preserve Stage 8 W1 scope and Stage 10 assurance conditions. |
+| Builder Appointment | `modules/amc/10-builder-appointment/builder-appointment.md` | 🟠 PACKAGE COMPLETE — ACKNOWLEDGMENT BLOCKED | Formal W1 appointment instruction, exact QA target, Ripple confirmation and Stage 12 boundary are defined. |
+| Builder Contract | `modules/amc/10-builder-appointment/builder-contract.md` | 🟠 OVERLAY COMPLETE — NOT YET BINDING | Exact W1 path allowlist, prohibitions, evidence and acceptance requirements are defined. |
+| Stage 11 Candidate Acknowledgment | `modules/amc/10-builder-appointment/integration-builder-stage11-acknowledgment.md` | 🔴 PENDING CANDIDATE RESPONSE | Candidate-authored acknowledgment and timestamp are mandatory before Stage 11 completion. |
+| Governance Sync Registry | `governance/alignment/canonical_sync_status.json` | ✅ ALIGNED / STABLE | `integration-builder` registry entry aligned to active contract v3.4.0. |
+
+Stage 11 is **BLOCKED — ACKNOWLEDGMENT PENDING**. The candidate is not constitutionally appointed until the acknowledgment is committed, independently verified, PR #1224 is merged, and CS2 accepts the appointment.
 
 ---
 

--- a/modules/amc/BUILD_PROGRESS_TRACKER.md
+++ b/modules/amc/BUILD_PROGRESS_TRACKER.md
@@ -47,7 +47,7 @@
 | 8 | Implementation Plan | ✅ CS2 APPROVED WITH CONDITIONS | Decision merged in PR #1202. |
 | 9 | Builder Checklist / W1 Readiness | ✅ COMPLETE — PASS ACCEPTED | Corrected readiness model accepted in PR #1216. |
 | 10 | IAA Pre-Brief | ✅ COMPLETE — `PREFLIGHT_BRIEF_COMPLETE` | Accepted through PR #1218 and reconciled in PR #1220. |
-| 11 | Builder Appointment | 🟡 ACTIVE — APPOINTMENT PROPOSED | `integration-builder` appointment and W1 contract are in PR #1224; not authoritative until merge/CS2 acceptance. |
+| 11 | Builder Appointment | 🔴 BLOCKED — ACKNOWLEDGMENT PENDING | Appointment package is complete in PR #1224, but the mandatory candidate-authored Stage 11 acknowledgment is not yet supplied. |
 | 12 | Build | ⬜ NOT STARTED — BLOCKED | No implementation authority; requires completed Stage 11 and separate Stage 12 authorization. |
 
 ## Stage 10 Final Facts
@@ -60,27 +60,43 @@
 
 ## Stage 11 W1 Appointment
 
-Proposed appointment:
+Appointment package:
 
 ```text
 Builder: integration-builder
 Class: Integration Builder
 Wave: W1 — Runtime Foundation and Environment Setup
-Post-merge state: APPOINTED — AWAITING STAGE 12 AUTHORIZATION
+Package status: COMPLETE
+Appointment status: BLOCKED — ACKNOWLEDGMENT PENDING
+Intended post-acceptance state: APPOINTED — AWAITING STAGE 12 AUTHORIZATION
 Implementation authorized: false
 ```
 
-The Stage 11 package defines:
+The Stage 11 package now defines:
 
-- constitutional onboarding and acknowledgment requirements;
+- formal constitutional appointment instruction;
+- exact architecture and QA suite references;
+- verified RED target of 9 mapped W1 obligations;
 - OPOJD and terminal-state discipline;
 - One-Time Build Law and 100% GREEN;
 - Zero Test Debt and zero warnings;
 - Architecture-as-Law and Design Freeze;
-- allowed W1 paths and prohibited actions;
+- exact W1 path allowlist and read-only authority paths;
+- prohibited Production, migration, credential, test and self-merge actions;
+- Ripple Intelligence confirmation with `ALIGNED` / `STABLE` status;
 - STOP and escalation conditions;
 - Foreman supervision and IAA review;
-- the strict separation between appointment and Stage 12 execution authority.
+- strict separation between appointment and Stage 12 execution authority.
+
+Candidate acknowledgment carrier:
+
+```text
+modules/amc/10-builder-appointment/integration-builder-stage11-acknowledgment.md
+```
+
+Current acknowledgment status: `PENDING CANDIDATE RESPONSE`.
+
+The Foreman cannot author or infer this response on the candidate's behalf. Stage 11 therefore remains blocked until the candidate supplies the explicit acknowledgment and timestamp and independent assurance verifies it.
 
 ## Implementation Plan Alignment
 
@@ -93,7 +109,7 @@ The Stage 11 package defines:
 - W1 and W2 must complete before material user-action work.
 - No wave has been skipped, reordered, or weakened.
 
-## W1 Build-Exit Evidence — Mandatory After Stage 12 Authorization
+## W1 Build-Exit Evidence — Mandatory Only After Stage 12 Authorization
 
 - `.github/workflows/ci.yml` creation and W1 proof, with W8 consolidation still required;
 - `.github/workflows/deploy-frontend.yml` creation and W1 proof, with W7 deployment validation still required;
@@ -107,15 +123,17 @@ The Stage 11 package defines:
 
 ## Current Disposition
 
-**Stages 1–10 are complete. Stage 11 is active but not yet accepted.**
+**Stages 1–10 are complete. Stage 11 package preparation is complete, but the appointment is constitutionally blocked pending the builder's explicit acknowledgment.**
 
-`integration-builder` remains readiness-approved and is proposed for appointment in PR #1224. No implementation may begin until Stage 11 is merged and CS2 separately authorizes Stage 12.
+`integration-builder` remains readiness-approved but not yet appointed. No implementation may begin. Stage 12 remains blocked.
 
 ## Current Artifacts
 
 - `modules/amc/10-builder-appointment/builder-appointment.md`
 - `modules/amc/10-builder-appointment/builder-contract.md`
+- `modules/amc/10-builder-appointment/integration-builder-stage11-acknowledgment.md`
 - `.github/agents/integration-builder.md`
+- `governance/alignment/canonical_sync_status.json`
 - `.agent-admin/assurance/iaa-wave-record-amc-w1-runtime-foundation.md`
 - `modules/amc/07-implementation-plan/implementation-plan.md`
 - `modules/amc/07-implementation-plan/wave-breakdown.md`
@@ -123,4 +141,4 @@ The Stage 11 package defines:
 
 ## Next Action
 
-Complete review and merge of PR #1224. After merge and CS2 acceptance, open a separate **Stage 12 — W1 Build Authorization and Implementation** issue. Do not begin implementation before that authorization.
+Obtain the candidate-authored Stage 11 acknowledgment in `integration-builder-stage11-acknowledgment.md`, refresh independent assurance, then complete review of PR #1224. Do not merge or open Stage 12 until the acknowledgment gate is satisfied.

--- a/modules/amc/BUILD_PROGRESS_TRACKER.md
+++ b/modules/amc/BUILD_PROGRESS_TRACKER.md
@@ -3,13 +3,13 @@
 **Module**: App Management Centre (AMC)  
 **Module Slug**: AMC  
 **Last Updated**: 2026-07-23  
-**Updated By**: Foreman proxy — Stage 10 post-merge alignment, issue #1219 / PR #1220
+**Updated By**: Foreman proxy — Stage 11 W1 Builder Appointment, issue #1223 / PR #1224
 
 > **Classification**: ACTIVE  
 > **Document Role**: PRIMARY LIVE CONTROL DOCUMENT  
 > **Canon Reference**: `PRE_BUILD_STAGE_MODEL_CANON.md` v1.0.0  
-> **Current Issue**: [app_management_centre#1219](https://github.com/APGI-cmy/app_management_centre/issues/1219)  
-> **Current PR**: [app_management_centre#1220](https://github.com/APGI-cmy/app_management_centre/pull/1220)  
+> **Current Issue**: [app_management_centre#1223](https://github.com/APGI-cmy/app_management_centre/issues/1223)  
+> **Current PR**: [app_management_centre#1224](https://github.com/APGI-cmy/app_management_centre/pull/1224)  
 > **Update Rule**: Update after every AMC stage issue, wave completion, approval, or readiness/blocker change.
 
 ## Disposition History
@@ -27,8 +27,10 @@
 - PR #1209 reconciled the record and retained BLOCKED.
 - PR #1214 merged the candidate re-attestation and truthful BLOCKED residual review.
 - PR #1216 merged the corrected W1 readiness model and accepted the Stage 9 W1 PASS.
-- PR #1218 merged the canonical Stage 10 W1 IAA Pre-Brief with disposition `PREFLIGHT_BRIEF_COMPLETE` at merge commit `7889309cf4f357894d496bde1bf79349a24bb450`.
-- Issue #1219 / PR #1220 reconciles post-merge tracker/index/pointer status only.
+- PR #1218 merged the canonical Stage 10 W1 IAA Pre-Brief with disposition `PREFLIGHT_BRIEF_COMPLETE`.
+- PR #1220 merged the authoritative Stage 10 post-merge reconciliation.
+- PR #1221 was closed unmerged as a duplicate superseded by PR #1220.
+- Issue #1223 / PR #1224 is the active Stage 11 W1 Builder Appointment wave.
 
 ## Stage Summary
 
@@ -43,110 +45,82 @@
 | 6 | QA-to-Red | ✅ CS2 APPROVED WITH CONDITIONS | QA-FD and QA-DEPLOY obligations remain binding. |
 | 7 | PBFAG | ✅ CS2 APPROVED WITH CONDITIONS | Evidence rows remain binding. |
 | 8 | Implementation Plan | ✅ CS2 APPROVED WITH CONDITIONS | Decision merged in PR #1202. |
-| 9 | Builder Checklist / W1 Readiness | ✅ COMPLETE — PASS ACCEPTED | Corrected pre-appointment readiness model accepted in merged PR #1216. |
-| 10 | IAA Pre-Brief | ✅ COMPLETE — `PREFLIGHT_BRIEF_COMPLETE` | Accepted through merged PR #1218; final token `IAA-session-1218-R2-20260723-PASS`. |
-| 11 | Builder Appointment | ⬜ NOT STARTED — ELIGIBLE PENDING EXPLICIT CS2 AUTHORIZATION | `integration-builder` remains nominated/readiness-approved but not appointed. |
-| 12 | Build | ⬜ NOT STARTED — BLOCKED | No implementation authority; requires completed Stage 11 appointment. |
+| 9 | Builder Checklist / W1 Readiness | ✅ COMPLETE — PASS ACCEPTED | Corrected readiness model accepted in PR #1216. |
+| 10 | IAA Pre-Brief | ✅ COMPLETE — `PREFLIGHT_BRIEF_COMPLETE` | Accepted through PR #1218 and reconciled in PR #1220. |
+| 11 | Builder Appointment | 🟡 ACTIVE — APPOINTMENT PROPOSED | `integration-builder` appointment and W1 contract are in PR #1224; not authoritative until merge/CS2 acceptance. |
+| 12 | Build | ⬜ NOT STARTED — BLOCKED | No implementation authority; requires completed Stage 11 and separate Stage 12 authorization. |
 
-## Stage 9 W1 Final Facts
+## Stage 10 Final Facts
 
-- Candidate: `integration-builder` — readiness PASS accepted; still not appointed.
-- Candidate v2 re-attestation: complete.
-- Vercel project `app-management-centre`: exists.
-- Supabase Production `icawesooswoqzepcdevg`: healthy.
-- Supabase non-production `develop` / `kkksclwvbmyexpsdyejj`: healthy.
-- GitHub/Vercel/Supabase owners, intended scopes and escalation paths: documented.
-- Preview/non-production versus Production design: documented.
-- Protected-Production policy and candidate prohibitions: documented.
-- Final Foreman role-fit: PASS under the corrected Stage 9 boundary.
+- Canonical carrier: `.agent-admin/assurance/iaa-wave-record-amc-w1-runtime-foundation.md`.
+- Disposition: `PREFLIGHT_BRIEF_COMPLETE`.
+- Final assurance token: `IAA-session-1218-R2-20260723-PASS`.
+- W1 scope and evidence requirements are fully defined.
+- No builder execution authority was created by Stage 10.
 
-## Stage 10 W1 IAA Pre-Brief
+## Stage 11 W1 Appointment
 
-Canonical carrier:
+Proposed appointment:
 
 ```text
-.agent-admin/assurance/iaa-wave-record-amc-w1-runtime-foundation.md
+Builder: integration-builder
+Class: Integration Builder
+Wave: W1 — Runtime Foundation and Environment Setup
+Post-merge state: APPOINTED — AWAITING STAGE 12 AUTHORIZATION
+Implementation authorized: false
 ```
 
-Final disposition:
+The Stage 11 package defines:
 
-```text
-PREFLIGHT_BRIEF_COMPLETE
-```
-
-Final assurance token:
-
-```text
-IAA-session-1218-R2-20260723-PASS
-```
-
-The accepted pre-brief defines:
-
-- exact W1 scope and exclusions;
-- applicable QA-to-Red and deployment obligations;
-- high-risk failure modes;
-- required builder outputs and reproducible evidence;
-- required Foreman quality-control checks;
-- ECAP applicability;
-- final IAA focus;
-- stop and escalation conditions.
+- constitutional onboarding and acknowledgment requirements;
+- OPOJD and terminal-state discipline;
+- One-Time Build Law and 100% GREEN;
+- Zero Test Debt and zero warnings;
+- Architecture-as-Law and Design Freeze;
+- allowed W1 paths and prohibited actions;
+- STOP and escalation conditions;
+- Foreman supervision and IAA review;
+- the strict separation between appointment and Stage 12 execution authority.
 
 ## Implementation Plan Alignment
 
-The current posture remains aligned with the approved Stage 8 implementation plan and wave breakdown:
-
-- W1 is the next delivery wave.
-- W1 scope remains Runtime Foundation and Environment Setup.
-- Required controls remain CI, Preview, secret and environment boundaries.
-- Required W1 RED coverage remains CI, Preview isolation, environment separation, secret boundaries and no-Production-side-effect tests.
+- W1 remains Runtime Foundation and Environment Setup.
+- Required controls remain CI, Preview, secret, and environment boundaries.
+- Required W1 RED coverage remains CI, Preview isolation, environment separation, secret boundaries, and no-Production-side-effect tests.
 - `.github/workflows/ci.yml` is introduced in W1 and remains a W8 consolidation/validation surface.
 - `.github/workflows/deploy-frontend.yml` is introduced in W1 and remains a W7 deployment-execution validation surface.
 - `db-migrate.yml` remains a W7 output.
 - W1 and W2 must complete before material user-action work.
-- No later wave is opened or reordered by the Stage 10 completion.
+- No wave has been skipped, reordered, or weakened.
 
-## W1 Build-Exit Evidence — Still Mandatory Later
+## W1 Build-Exit Evidence — Mandatory After Stage 12 Authorization
 
 - `.github/workflows/ci.yml` creation and W1 proof, with W8 consolidation still required;
 - `.github/workflows/deploy-frontend.yml` creation and W1 proof, with W7 deployment validation still required;
-- validation/update of the existing root `.env.example` without secrets;
+- validation/update of root `.env.example` without secrets;
 - executed CI/type/lint/test/schema logs;
 - actual Preview-to-`develop` binding;
 - Production credential exclusion;
 - no-Production-side-effect proof;
 - deployment/isolation execution evidence;
-- W1 RED-to-GREEN evidence.
-
-`db-migrate.yml` remains a W7 output.
+- W1 RED-to-GREEN evidence and PREHANDOVER_PROOF.
 
 ## Current Disposition
 
-**Stages 1–10 are complete for W1 pre-build progression.**
+**Stages 1–10 are complete. Stage 11 is active but not yet accepted.**
 
-Stage 11 is now the next eligible governed stage but is not yet authorized. Stage 12 remains blocked. No builder is appointed and no implementation work has begun.
+`integration-builder` remains readiness-approved and is proposed for appointment in PR #1224. No implementation may begin until Stage 11 is merged and CS2 separately authorizes Stage 12.
 
 ## Current Artifacts
 
+- `modules/amc/10-builder-appointment/builder-appointment.md`
+- `modules/amc/10-builder-appointment/builder-contract.md`
+- `.github/agents/integration-builder.md`
+- `.agent-admin/assurance/iaa-wave-record-amc-w1-runtime-foundation.md`
 - `modules/amc/07-implementation-plan/implementation-plan.md`
 - `modules/amc/07-implementation-plan/wave-breakdown.md`
 - `modules/amc/07-implementation-plan/condition-import-matrix.md`
-- `modules/amc/08-builder-checklist/w1-bootstrap-readiness-model-correction-20260723.md`
-- `modules/amc/08-builder-checklist/executions/w1/integration-builder-readiness-checklist.md`
-- `.agent-admin/assurance/iaa-wave-record-amc-w1-runtime-foundation.md`
-- `.agent-admin/wave-records/amc-wave-record-stage10-w1-iaa-prebrief-1218.md`
-- `.agent-admin/prehandover/ecap-reconciliation-1218.md`
-- `.agent-workspace/independent-assurance-agent/memory/session-1218-20260723.md`
-- `modules/amc/09-iaa-pre-brief/iaa-pre-brief.md`
 
 ## Next Action
 
-Complete and merge Issue #1219 / PR #1220. After that, CS2 may explicitly authorize **Stage 11 — W1 Builder Appointment**. Do not begin Stage 12 implementation before Stage 11 is completed and separately accepted.
-
-## References
-
-- `modules/amc/07-implementation-plan/implementation-plan.md`
-- `modules/amc/07-implementation-plan/wave-breakdown.md`
-- `modules/amc/07-implementation-plan/condition-import-matrix.md`
-- `modules/amc/08-builder-checklist/builder-checklist.md`
-- `modules/amc/08-builder-checklist/w1-bootstrap-readiness-model-correction-20260723.md`
-- `modules/amc/AMC_PRE_BUILD_ARTIFACT_INDEX.md`
+Complete review and merge of PR #1224. After merge and CS2 acceptance, open a separate **Stage 12 — W1 Build Authorization and Implementation** issue. Do not begin implementation before that authorization.


### PR DESCRIPTION
## Summary

governing_issue: #1223
entry_condition_status: NORMAL

CS2 authorized Stage 11 preparation for AMC W1. This PR now contains the complete constitutional appointment package for `integration-builder` for **W1 — Runtime Foundation and Environment Setup**.

## Completed package

- Formal Stage 11 appointment instruction.
- W1-specific builder contract overlay.
- Exact architecture reference.
- Exact QA suite carrier and verified RED target of nine mapped W1 obligations.
- OPOJD, terminal-state execution, One-Time Build Law, 100% GREEN, Zero Test Debt, Architecture-as-Law, Execution Bootstrap and PREHANDOVER_PROOF bindings.
- Exact writable-path allowlist and read-only authority paths.
- Production, migration, credential, test-weakening, self-approval and self-merge prohibitions.
- Correct W1/W7/W8 workflow mappings.
- Ripple Intelligence confirmation with `ALIGNED` / `STABLE` status and contract registry v3.4.0.
- Candidate-owned acknowledgment carrier.
- Progress tracker and artifact-index alignment.
- PR-specific Foreman, ECAP and IAA records.

## Current Stage 11 disposition

`BLOCKED — CANDIDATE ACKNOWLEDGMENT REQUIRED`

The mandatory acknowledgment carrier is:

```text
modules/amc/10-builder-appointment/integration-builder-stage11-acknowledgment.md
```

The carrier currently contains `CANDIDATE RESPONSE: PENDING`. The Foreman, ECAP and IAA may not author or infer the candidate's constitutional acknowledgment.

Until `integration-builder` supplies the explicit acknowledgment and timestamp:

- Stage 11 is incomplete;
- the builder is not constitutionally appointed;
- this PR is not merge-ready;
- Stage 12 remains blocked;
- implementation authority remains false.

## Intended post-acceptance state

Only after candidate acknowledgment, refreshed independent assurance, merge and CS2 acceptance:

```text
APPOINTED — AWAITING STAGE 12 AUTHORIZATION
```

## Boundary

This PR does not:

- authorize Stage 12;
- begin W1 implementation;
- create `ci.yml`, `deploy-frontend.yml`, or `db-migrate.yml`;
- run tests as build evidence;
- change Supabase, Vercel, Render, schema, migration, or Production settings;
- deploy any environment;
- create QA-to-GREEN evidence.

- Fixes #1223